### PR TITLE
fix:the alinode-v4.8.2 is not compatible in centos6

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,10 @@
       ">= 4.0.0 < 4.7.1": {
         "version": "4.7.1",
         "reason": "https://nodejs.org/en/blog/vulnerability/february-2019-security-releases/"
+      },
+      "=4.8.2": {
+        "version": "4.8.0",
+        "reason": "https://github.com/cnpm/bug-versions/issues/57"
       }
     },
     "bug-versions": {


### PR DESCRIPTION
4.8.2版本在centos6中不兼容，后续会在4.8.3版本解决该问题