### PR TITLE
feat: August 2019 Security Releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,17 +38,21 @@
         "version": "6.17.0",
         "reason": "https://nodejs.org/en/blog/vulnerability/february-2019-security-releases/"
       },
-      ">= 8.0.0 < 8.15.1": {
-        "version": "8.15.1",
-        "reason": "https://nodejs.org/en/blog/vulnerability/february-2019-security-releases/"
+      ">= 8.0.0 < 8.16.1": {
+        "version": "8.16.1",
+        "reason": "https://nodejs.org/en/blog/vulnerability/aug-2019-security-releases/"
       },
-      ">= 10.0.0 < 10.15.2": {
-        "version": "10.15.2",
-        "reason": "https://nodejs.org/en/blog/vulnerability/february-2019-security-releases/"
+      ">= 10.0.0 < 10.16.3": {
+        "version": "10.16.3",
+        "reason": "https://nodejs.org/en/blog/vulnerability/aug-2019-security-releases/"
       },
       ">= 11.0.0 < 11.10.1": {
         "version": "11.10.1",
         "reason": "https://nodejs.org/en/blog/vulnerability/february-2019-security-releases/"
+      },
+      ">= 12.0.0 < 12.9.0": {
+        "version": "12.9.0",
+        "reason": "https://nodejs.org/en/blog/vulnerability/aug-2019-security-releases/"
       }
     },
     "unsafe-alinode-versions": {
@@ -60,21 +64,17 @@
         "version": "2.7.0",
         "reason": "https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/"
       },
-      ">= 3.0.0 < 3.14.0": {
-        "version": "3.14.0",
-        "reason": "https://github.com/nodejs/node/pull/24811"
+      ">= 3.0.0 < 3.15.1": {
+        "version": "3.15.1",
+        "reason": "https://nodejs.org/en/blog/vulnerability/aug-2019-security-releases/"
       },
-      "=3.14.1": {
-        "version": "3.14.0",
-        "reason": "https://github.com/nodejs/node/issues/26366#issuecomment-469565411"
+      ">= 4.0.0 < 4.8.3": {
+        "version": "4.8.3",
+        "reason": "https://nodejs.org/en/blog/vulnerability/aug-2019-security-releases/"
       },
-      ">= 4.0.0 < 4.7.1": {
-        "version": "4.7.1",
-        "reason": "https://nodejs.org/en/blog/vulnerability/february-2019-security-releases/"
-      },
-      "=4.8.2": {
-        "version": "4.8.0",
-        "reason": "https://github.com/cnpm/bug-versions/issues/57"
+      ">= 5.0.0 < 5.8.1": {
+        "version": "5.8.1",
+        "reason": "https://nodejs.org/en/blog/vulnerability/aug-2019-security-releases/"
       }
     },
     "bug-versions": {


### PR DESCRIPTION
auto fix node and alinode unsafe versions

see https://nodejs.org/en/blog/vulnerability/aug-2019-security-releases/