### PR TITLE
feat: add typescript-eslint/parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -474,6 +474,10 @@
           "version": "1.3.0",
           "reason": "https://github.com/svg/svgo/issues/1174"
         }
+      },
+      "@typescript-eslint/parser": {
+        "version": "2.11.1-alpha.2",
+        "reason": "https://github.com/umijs/fabric/issues/17"
       }
     }
   },


### PR DESCRIPTION
* @umijs/fabric@1.2.4 引用了 @typescript-eslint/parser@2.11.1-alpha.2
* @typescript-eslint/parser@2.11.1-alpha.2 锁版本引用了 @typescript-eslint/typescript-estree@2.11.1-alpha.2
* @typescript-eslint/typescript-estree@2.11.1-alpha.2 在 npm 上不存在