### PR TITLE
fix/moment-err-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -505,6 +505,10 @@
         "2.25.0": {
           "version": "2.24.0",
           "reason": "https://github.com/moment/moment/issues/5481"
+        },
+        "2.25.1": {
+          "version": "2.24.0",
+          "reason": "https://github.com/moment/moment/issues/5481"
         }
       }
     }


### PR DESCRIPTION
与 2.25.0 同样的问题，还是没有解决
![image](https://user-images.githubusercontent.com/20394320/80853469-d0be3a00-8c63-11ea-868b-7c7232bcb289.png)
