### PR TITLE
feat: hotfix lodash@4.17.16-18 to 4.17.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -528,6 +528,16 @@
           "version": "1.2.7",
           "reason": "https://github.com/formatjs/formatjs/issues/1773"
         }
+      },
+      "lodash": {
+        "4.17.16": {
+          "version": "4.17.15",
+          "reason": "https://github.com/lodash/lodash/issues/4846"
+        },
+        "4.17.17": {
+          "version": "4.17.15",
+          "reason": "https://github.com/lodash/lodash/issues/4848"
+        }
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -537,6 +537,10 @@
         "4.17.17": {
           "version": "4.17.15",
           "reason": "https://github.com/lodash/lodash/issues/4848"
+        },
+        "4.17.18": {
+          "version": "4.17.15",
+          "reason": "https://github.com/lodash/lodash/issues/4850"
         }
       }
     }


### PR DESCRIPTION
lodash v4.17.16 and v4.17.17 causing an error of module `lodash/fp` cannot be found.
see `lodash` issue [4846](https://github.com/lodash/lodash/issues/4846), [4848](https://github.com/lodash/lodash/issues/4848).
![image](https://user-images.githubusercontent.com/4635838/86924701-6691ac00-c162-11ea-835e-e9f020273b6f.png)

lodash v4.17.18 causing an error of module `lodash/core` cannot be found.
see `lodash` issue [4850](https://github.com/lodash/lodash/issues/4850).

![image](https://user-images.githubusercontent.com/4635838/86949234-edee1800-c180-11ea-8acf-375cdb321f5b.png)
