### PR TITLE
fix: intl-messageformat-parser incompatible versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -559,6 +559,16 @@
           "version": "4.15.4",
           "reason": "breaking change"
         }
+      },
+      "intl-messageformat-parser": {
+        "5.5.1": {
+          "version": "5.4.2",
+          "reason": "https://github.com/formatjs/formatjs/issues/2005"
+        },
+        "5.5.0": {
+          "version": "5.4.2",
+          "reason": "https://github.com/formatjs/formatjs/issues/2005"
+        }
       }
     }
   },


### PR DESCRIPTION
intl-messageformat@8.4.1 依赖 intl-messageformat-parser@^5.2.1，最近 intl-messageformat-parser 发版了 5.5.x，导致 intl-messageformat 挂掉，也导致我们后续的打包流程挂掉。

报错信息：https://github.com/formatjs/formatjs/issues/2005

相关文件对比：
https://unpkg.com/browse/intl-messageformat-parser@5.5.0/src/skeleton.js
https://unpkg.com/browse/intl-messageformat-parser@5.4.2/src/skeleton.js