### PR TITLE
fix: revert alinode-v4 LTS line for GLIBC dependencies breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,9 +83,9 @@
         "version": "3.16.0",
         "reason": "https://nodejs.org/en/blog/vulnerability/december-2019-security-releases/"
       },
-      ">= 4.0.0 < 4.12.1": {
-        "version": "4.12.1",
-        "reason": "https://nodejs.org/en/blog/vulnerability/september-2020-security-releases/"
+      ">= 4.0.0 < 4.10.0": {
+        "version": "4.10.0",
+        "reason": "https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/"
       },
       ">= 5.0.0 < 5.16.4": {
         "version": "5.16.4",


### PR DESCRIPTION
Alinode v4 LTS release line should not require following GLIBC/GLIBCXX versions:
GLIBCXX_3.4.14
GLIBCXX_3.4.18
GLIBCXX_3.4.11
GLIBCXX_3.4.15
GLIBC_2.17
GLIBC_2.16
GLIBC_2.14

Revert for now. There will be a quick follow up version to address the security concerns.