### PR TITLE
fix:graceful-fs fs.copyFile breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -627,6 +627,12 @@
           "version": "1.13.1",
           "reason": "https://github.com/ant-design/babel-plugin-import/issues/557"
         }
+      },
+      "graceful-fs": {
+        "4.2.5": {
+          "version": "4.2.5",
+          "reason": "fs.copyFile breaking change"
+        }
       }
     }
   },


### PR DESCRIPTION
nodejs fs.copyFile 内支持第三个参数为 mode（[见 nodejs fs 代码](https://github.com/nodejs/node/blob/master/lib/fs.js#L2024)），当代码使用 `fs.copyFile` 拷贝文件并指定第三个参数，如 `await fs.copyFile(src, dist, null)` 时

在 graceful-fs@4.2.4 中，由于 graceful-fs 未针对 fs.copyFile 进行特殊处理，因此逻辑正常，在 thenify 中能正常在 callback 中执行 resolve。

在 graceful-fs@4.2.5 中，[由于 graceful-fs 包裹了一层](https://github.com/isaacs/node-graceful-fs/compare/v4.2.4...v4.2.5#diff-05bab169a94002226e0f82bf51c510b4fd2c6cd53f5d558c1ea4136c24a0d7c8R173)，导致第三个参数被 thenify 固定识别为 callback，但实际传入的是 mode，也就是 null，从而导致 resolve 永远无法执行，进而 await 被卡死

