### PR TITLE
fix: optimize-css-assets-webpack-plugin@5.0.7 to 5.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -412,6 +412,12 @@
           "reason": "https://npm.community/t/npm-pack-leaving-out-files-6-8-0-only/5382/5"
         }
       },
+      "optimize-css-assets-webpack-plugin": {
+        "5.0.7": {
+          "version": "5.0.6",
+          "reason": "https://github.com/NMFR/optimize-css-assets-webpack-plugin/issues/167"
+        }
+      },
       "supertest": {
         "3.4.0": {
           "version": "3.3.0",


### PR DESCRIPTION
https://github.com/NMFR/optimize-css-assets-webpack-plugin/issues/167

optimize-css-assets-webpack-plugin 5 个小时前发布了 5.0.7 版本，相比 5.0.6，其中一个变化是 postcss 从传递依赖的 7.x 变为了直接依赖 8.x，导致构建报错。

![image](https://user-images.githubusercontent.com/646129/123024013-fdef1e00-d40a-11eb-9190-8d8deba9af2f.png)

