### PR TITLE
fix: react-jss 10.7.0 to 10.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -675,6 +675,12 @@
           "version": "2.0.7",
           "reason": "https://github.com/markedjs/marked/issues/2106"
         }
+      },
+      "react-jss": {
+        "10.7.0": {
+          "version": "10.6.0",
+          "reason": "https://github.com/cssinjs/jss/issues/1525"
+        }
       }
     }
   },


### PR DESCRIPTION
https://github.com/cssinjs/jss/issues/1525

他们的一个内部重构搞成了不兼容更新...