### PR TITLE
feat: nodejs july 2021 security releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,21 +57,25 @@
         "version": "11.10.1",
         "reason": "https://nodejs.org/en/blog/vulnerability/february-2019-security-releases/"
       },
-      ">= 12.0.0 < 12.21.0": {
-        "version": "12.21.0",
-        "reason": "https://nodejs.org/en/blog/vulnerability/february-2021-security-releases/"
+      ">= 12.0.0 < 12.22.3": {
+        "version": "12.22.3",
+        "reason": "https://nodejs.org/en/blog/vulnerability/july-2021-security-releases/"
       },
       ">= 13.0.0 < 13.8.0": {
         "version": "13.8.0",
         "reason": "https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/"
       },
-      ">= 14.0.0 < 14.16.0": {
-        "version": "14.16.0",
-        "reason": "https://nodejs.org/en/blog/vulnerability/february-2021-security-releases/"
+      ">= 14.0.0 < 14.17.3": {
+        "version": "14.17.3",
+        "reason": "https://nodejs.org/en/blog/vulnerability/july-2021-security-releases/"
       },
       ">= 15.0.0 < 15.10.0": {
         "version": "15.10.0",
         "reason": "https://nodejs.org/en/blog/vulnerability/february-2021-security-releases/"
+      },
+      ">= 16.0.0 < 16.4.2": {
+        "version": "16.4.2",
+        "reason": "https://nodejs.org/en/blog/vulnerability/july-2021-security-releases/"
       }
     },
     "unsafe-alinode-versions": {


### PR DESCRIPTION
https://nodejs.org/en/blog/vulnerability/july-2021-security-releases/

use the LTS latest version for 12, 14, 16