### PR TITLE
fix: uglify-js 3.14.0 to 3.13.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "bug-versions": {
       "uglify-js": {
         "3.14.0": {
-          "version": "3.14.0",
+          "version": "3.13.10",
           "reason": "https://github.com/mishoo/UglifyJS/issues/5102"
         }
       },

--- a/package.json
+++ b/package.json
@@ -116,6 +116,12 @@
       }
     },
     "bug-versions": {
+      "uglify-js": {
+        "3.14.0": {
+          "version": "3.14.0",
+          "reason": "https://github.com/mishoo/UglifyJS/issues/5102"
+        }
+      },
       "react-color": {
         "2.19.1": {
           "version": "2.18.1",


### PR DESCRIPTION
<!-- Note: sub-optimal but correct code is not a bug -->
```js
var UglifyJS = require("uglify-js");

var code = "function aaa(t) { return t.default; }";
var result = UglifyJS.minify(code, {
  ie8: true
});
console.log(result.error); // runtime error, or `undefined` if no error
console.log(result.code);  //
```
<!--
A complete parsable JS program exhibiting the issue with UglifyJS alone
- without third party tools or libraries.

Ideally the input should be as small as possible, but may be large if isolating
the problem proves to be difficult. The most important thing is that the
standalone program reliably exhibits the bug when minified. Provide a link to a
gist if necessary.

Solely providing minified output without the original uglify JS input is not
useful in determining the cause of the problem. Issues without a reproducible
test case will be closed.
-->

**The `uglifyjs` CLI command executed or `minify()` options used.**

<!--
Command-line or API call to UglifyJS without third party tools or libraries.

For users using bundlers or transpilers, you may be able to gather the required
information through setting the `UGLIFY_BUG_REPORT` environment variable:

    export UGLIFY_BUG_REPORT=1      (bash)
    set UGLIFY_BUG_REPORT=1         (Command Prompt)
    $Env:UGLIFY_BUG_REPORT=1        (PowerShell)

before running your usual build process. The resulting "minified" output should
contain the necessary details for this report.
-->

in version 3.14.0，the behavior of "default" is not working

**JavaScript output or error produced.**

in version 3.13.10

> function aaa(a){return a["default"]}

in version 3.14.10
> function aaa(a){return a.default}

<!--
Only minified code that produces different output (or error) from the original
upon execution would be considered a bug.
-->
