### PR TITLE
fix: ua-parser-js 0.7.29, 0.8.0, 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,20 @@
       }
     },
     "bug-versions": {
+      "ua-parser-js": {
+        "1.0.2": {
+          "version": "0.7.29",
+          "reason": "https://github.com/faisalman/ua-parser-js/issues/536"
+        },
+        "1.0.2": {
+          "version": "0.8.0",
+          "reason": "https://github.com/faisalman/ua-parser-js/issues/536"
+        },
+        "1.0.2": {
+          "version": "1.0.0",
+          "reason": "https://github.com/faisalman/ua-parser-js/issues/536"
+        }
+      },
       "uglify-js": {
         "3.14.0": {
           "version": "3.13.10",


### PR DESCRIPTION
ua-parser-js Security issue #155