### PR TITLE
fix: gifsicle 5.3.0->5.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,12 @@
       }
     },
     "bug-versions": {
+      "gifsicle": {
+        "5.3.0": {
+          "version": "5.2.1",
+          "reason": "https://github.com/imagemin/gifsicle-bin/issues/133"
+        }
+      },
       "coa": {
         "2.0.3": {
           "version": "2.0.2",


### PR DESCRIPTION
https://github.com/imagemin/gifsicle-bin/issues/133

gifsicle -> post-install -> bin-wrapper -> https://raw.githubusercontent.com/imagemin/gifsicle-bin/v5.3.0/vendor/linux/x64/gifsicle  -> 404
