### PR TITLE
 fix: math-expression-evaluator@1.3.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -842,6 +842,12 @@
           "version": "4.1.14",
           "reason": "https://github.com/DefinitelyTyped/DefinitelyTyped/issues/58445"
         }
+      },
+      "math-expression-evaluator": {
+        "1.3.12": {
+          "version": "1.3.11",
+          "reason": "https://github.com/bugwheels94/math-expression-evaluator/issues/37"
+        }
       }
     }
   },


### PR DESCRIPTION
math-expression-evaluator 的构建依赖了 webpack@5 但是它声明成了 dependencies 导致很多 webpack@4 的项目构建失败。

![image](https://user-images.githubusercontent.com/2794349/151488866-cde53bf9-144a-4892-91dc-f38ec13c5b19.png)
