### PR TITLE
fix: add which-pm-runs@1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -852,7 +852,7 @@
       },
       "which-pm-runs": {
         "1.1.0": {
-          "version": "1.1.0",
+          "version": "1.0.0",
           "reason": "https://github.com/zkochan/packages/commit/e7af82f03f1afe6086312d80a0fa47eb8d1c6bff"
         }
       }

--- a/package.json
+++ b/package.json
@@ -849,6 +849,12 @@
           "version": "1.3.11",
           "reason": "https://github.com/bugwheels94/math-expression-evaluator/issues/37"
         }
+      },
+      "which-pm-runs": {
+        "1.1.0": {
+          "version": "1.1.0",
+          "reason": "https://github.com/zkochan/packages/commit/e7af82f03f1afe6086312d80a0fa47eb8d1c6bff"
+        }
       }
     }
   },


### PR DESCRIPTION
这个版本会导致 cnpm/tnpm 场景下使用 husky@4 失效。

原因如下，

1、husky 依赖 which-pm-runs 计算 package manager
2、which-pm-runs 4 天前发布了 1.1.0 版本，加上了 cnpm 的处理逻辑，参考 https://github.com/zkochan/packages/commit/e7af82f03f1afe6086312d80a0fa47eb8d1c6bff
3、这本身没有问题，但 husky@4.x 对此没处理好，只通过白名单的方式支持 npm、npminstall、pnpm 和 yarn，加上 cnpm 之后直接退出，参考 https://github.com/typicode/husky/blob/v4.3.8/sh/husky.sh#L84-L90 ，这让使用 cnpm 或 tnpm 安装 husky@4 时 pre-commit 直接失效

临时方案，

修改 .git/hooks/husky.local.sh，替换 cnpm 为 npm。