### PR TITLE
security: harden build process

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,7 +32,11 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@v1
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        egress-policy: block
+        disable-telemetry: true
+        allowed-endpoints: >
+          github.com:443
+          registry.npmjs.org:443
 
     - name: Checkout Git Source
       uses: actions/checkout@v2

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,6 +15,9 @@ on:
   schedule:
     - cron: '0 2 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -26,6 +29,11 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@v1
+      with:
+        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
     - name: Checkout Git Source
       uses: actions/checkout@v2
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,6 +36,7 @@ jobs:
         disable-telemetry: true
         allowed-endpoints: >
           github.com:443
+          registry.npmjs.com:443
           registry.npmjs.org:443
 
     - name: Checkout Git Source


### PR DESCRIPTION
This PR adds https://github.com/step-security/harden-runner GitHub Action to this workflow. It can help detect compromised dependencies and build tools. 

You can see the analysis when run on the fork here: https://app.stepsecurity.io/github/varunsh-coder/bug-versions/actions/runs/1935141573

Here are couple of examples:
https://github.com/nvm-sh/nvm/blob/master/.github/workflows/lint.yml#L11-L16
https://github.com/yannickcr/eslint-plugin-react/blob/master/.github/workflows/release.yml#L18-L22

The PR also sets minimum token permissions for the GitHub token. 

Please let me know if you have any questions. Thanks!