### PR TITLE
feat: openssl security releases require Node.js security releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,29 +58,29 @@
         "version": "11.10.1",
         "reason": "https://nodejs.org/en/blog/vulnerability/february-2019-security-releases/"
       },
-      ">= 12.0.0 < 12.22.9": {
-        "version": "12.22.9",
-        "reason": "https://nodejs.org/en/blog/vulnerability/jan-2022-security-releases/"
+      ">= 12.0.0 < 12.22.11": {
+        "version": "12.22.11",
+        "reason": "https://nodejs.org/en/blog/vulnerability/mar-2022-security-releases/"
       },
       ">= 13.0.0 < 13.8.0": {
         "version": "13.8.0",
         "reason": "https://nodejs.org/en/blog/vulnerability/february-2020-security-releases/"
       },
-      ">= 14.0.0 < 14.18.3": {
-        "version": "14.18.3",
-        "reason": "https://nodejs.org/en/blog/vulnerability/jan-2022-security-releases/"
+      ">= 14.0.0 < 14.19.1": {
+        "version": "14.19.1",
+        "reason": "https://nodejs.org/en/blog/vulnerability/mar-2022-security-releases/"
       },
       ">= 15.0.0 < 15.10.0": {
         "version": "15.10.0",
         "reason": "https://nodejs.org/en/blog/vulnerability/february-2021-security-releases/"
       },
-      ">= 16.0.0 < 16.13.2": {
-        "version": "16.13.2",
-        "reason": "https://nodejs.org/en/blog/vulnerability/jan-2022-security-releases/"
+      ">= 16.0.0 < 16.14.2": {
+        "version": "16.14.2",
+        "reason": "https://nodejs.org/en/blog/vulnerability/mar-2022-security-releases/"
       },
-      ">= 17.0.0 < 17.3.1": {
-        "version": "17.3.1",
-        "reason": "https://nodejs.org/en/blog/vulnerability/jan-2022-security-releases/"
+      ">= 17.0.0 < 17.7.2": {
+        "version": "17.7.2",
+        "reason": "https://nodejs.org/en/blog/vulnerability/mar-2022-security-releases/"
       }
     },
     "unsafe-alinode-versions": {


### PR DESCRIPTION
see https://nodejs.org/en/blog/vulnerability/mar-2022-security-releases/