### PR TITLE
fix: restore which-pm-runs@1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -860,12 +860,6 @@
           "reason": "https://github.com/bugwheels94/math-expression-evaluator/issues/37"
         }
       },
-      "which-pm-runs": {
-        "1.1.0": {
-          "version": "1.0.0",
-          "reason": "https://github.com/zkochan/packages/commit/e7af82f03f1afe6086312d80a0fa47eb8d1c6bff"
-        }
-      },
       "tablestore": {
         "5.1.0": {
           "version": "5.0.7",


### PR DESCRIPTION
Related: https://github.com/cnpm/bug-versions/pull/174

Restore `which-pm-runs@1.1.0` if `husky` has already fixed the issue.