### PR TITLE
Revert "fix: lock babel-traverse 7.17.10 to 7.17.9"

### DIFF
--- a/package.json
+++ b/package.json
@@ -904,12 +904,6 @@
           },
           "reason": "https://github.com/styled-components/styled-components/commit/ba9d732ca7da53f2a095e35450ecffd592c6f5ba"
         }
-      },
-      "@babel/traverse": {
-        "7.17.10": {
-          "version": "7.17.9",
-          "reason": "https://github.com/babel/babel/issues/14525"
-        }
       }
     }
   },


### PR DESCRIPTION
Reverts cnpm/bug-versions#192

https://github.com/babel/minify/issues/1028#issuecomment-1114982399

这个是babel-minify依赖了有bug的行为，babel-traverse本身没问题