### PR TITLE
feat: use ip@1.1.5 instead of 1.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -892,6 +892,12 @@
           "reason": "https://github.com/isaacs/node-lru-cache/pull/217/files"
         }
       },
+      "ip": {
+        "1.1.6": {
+          "version": "1.1.5",
+          "reason": "https://github.com/indutny/node-ip/issues/115"
+        }
+      },
       "styled-components": {
         "5.3.4": {
           "version": "5.3.3",


### PR DESCRIPTION
https://github.com/indutny/node-ip/issues/115

breaking change https://github.com/indutny/node-ip/commit/4de50aec875d12b004849e11e19d6daf68b50c2d#diff-fd54b600aed6dd1ffe98402e1d4f801e8525368113f6a62ff51c81f4c7fa16f9R203