### PR TITLE
chore: switch from `node-core-test` to `test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -925,8 +925,8 @@
     "find-duplicated-property-keys": "^1.2.7",
     "git-contributor": "^1.0.10",
     "husky": "^4.2.5",
-    "node-core-test": "^2.0.0",
-    "semantic-release": "^18.0.1"
+    "semantic-release": "^18.0.1",
+    "test": "^3.0.0"
   },
   "ci": {
     "type": "github",

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assert = require('assert');
-const test = require('node-core-test')
+const test = require('test');
 const bugVersions = require('.');
 
 test('should get bug-versions', () => {


### PR DESCRIPTION
The project has been moved to the `nodejs` org https://github.com/nodejs/node-core-test and has the new npm name `test`.