### PR TITLE
fix: Remove gifsicle 5.3.0 -> 5.2.1 overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,12 +135,6 @@
           "reason": "https://github.com/Marak/colors.js/issues/289"
         }
       },
-      "gifsicle": {
-        "5.3.0": {
-          "version": "5.2.1",
-          "reason": "https://github.com/imagemin/gifsicle-bin/issues/133"
-        }
-      },
       "coa": {
         "2.0.3": {
           "version": "2.0.2",


### PR DESCRIPTION
https://github.com/imagemin/gifsicle-bin/issues/133#issuecomment-979906835

https://www.npmjs.com/package/gifsicle/v/5.3.0

Author has released version 5.3.0.