### PR TITLE
feat: 增加vuescroll@4.17.4,原因是依赖的服务问题导致不可用

### DIFF
--- a/package.json
+++ b/package.json
@@ -949,6 +949,12 @@
           "version": "7.20.5",
           "reason": "https://github.com/babel/babel/issues/15295"
         }
+      },
+      "vuescroll": {
+        "4.17.4": {
+          "version": "4.17.3",
+          "reason": "https://github.com/YvesCoding/vuescroll/issues/285"
+        }
       }
     }
   }


### PR DESCRIPTION
具体服务：https://github.com/YvesCoding/vuescroll/issues/285