### PR TITLE
feat: add alertify.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -979,6 +979,12 @@
           "version": "7.21.4",
           "reason": "https://github.com/babel/babel/issues/15597"
         }
+      },
+      "alertify.js": {
+        "1.0.12": {
+          "version": "1.0.11",
+          "reason": "https://github.com/alertifyjs/alertify.js/issues/160"
+        }
       }
     }
   }


### PR DESCRIPTION
> alertify.js has set snyk in deps, which causes the snyk postinstall script to be triggered. alertify.js seems to alertify.js has stopped updating. https://github.com/alertifyjs/alertify.js/issues/160
* 🔄 Downgrade alertify.js from version `1.0.2` to `1.0.1`
--------------
> alertify.js 在 deps 中依赖了 snyk ，导致默认触发 snyk 的 postinstall 脚本，目前似乎已经停止更新 https://github.com/alertifyjs/alertify.js/issues/160
* ♻️ 将 alertify.js 的 `1.0.2` 版本指向 `1.0.1`