### PR TITLE
feat: add icons/material

### DIFF
--- a/package.json
+++ b/package.json
@@ -985,6 +985,12 @@
           "version": "1.0.11",
           "reason": "https://github.com/alertifyjs/alertify.js/issues/160"
         }
+      },
+      "@icons/material": {
+        "0.2.4": {
+          "version": "0.4.1",
+          "reason": "https://github.com/at-icons/material/issues/4"
+        }
       }
     }
   }


### PR DESCRIPTION
**@icons/material@0.2.4** has incorrect export, which casues deps parse failed.(there is no file named **StackOverflowIcon.js** which should be **StackoverflowIcon.js**)
`export { default as StackOverflowIcon } from './StackOverflowIcon.js'`

- upgrade to version 0.4.1