### PR TITLE
feat: node.js wednesday february 14 2024 security releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,13 +74,17 @@
         "version": "16.20.2",
         "reason": "https://nodejs.org/en/blog/vulnerability/august-2023-security-releases"
       },
-      ">= 18.0.0 < 18.18.2": {
-        "version": "18.18.2",
-        "reason": "https://nodejs.org/en/blog/vulnerability/october-2023-security-releases"
+      ">= 18.0.0 < 18.19.1": {
+        "version": "18.19.1",
+        "reason": "https://nodejs.org/en/blog/vulnerability/february-2024-security-releases/"
       },
-      ">= 20.0.0 < 20.8.1": {
-        "version": "20.8.1",
-        "reason": "https://nodejs.org/en/blog/vulnerability/october-2023-security-releases"
+      ">= 20.0.0 < 20.11.1": {
+        "version": "20.11.1",
+        "reason": "https://nodejs.org/en/blog/vulnerability/february-2024-security-releases/"
+      },
+      ">= 21.0.0 < 21.6.2": {
+        "version": "21.6.2",
+        "reason": "https://nodejs.org/en/blog/vulnerability/february-2024-security-releases/"
       }
     },
     "unsafe-alinode-versions": {


### PR DESCRIPTION
https://nodejs.org/en/blog/vulnerability/february-2024-security-releases/