### PR TITLE
feat: add @babel/traverse@7.25.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1026,6 +1026,10 @@
         "7.22.7": {
           "version": "7.22.6",
           "reason": "https://github.com/babel/babel/issues/15752"
+        },
+        "7.25.1": {
+          "version": "7.24.8",
+          "reason": "https://github.com/babel/babel/issues/16684"
         }
       },
       "fsevents": {


### PR DESCRIPTION
ref: https://github.com/babel/babel/issues/16684

和 Umi 3/4 预打包的 babel 版本混用时会出现这个问题，先通过 bug-versions 争取修复时间

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Babel package version to 7.25.1 for improved dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->