### PR TITLE
feat: add @swc/types@0.1.16 as a bug version, fallback to 0.1.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -992,6 +992,12 @@
           "reason": "https://github.com/swc-project/swc/issues/7203"
         }
       },
+      "@swc/types": {
+        "0.1.16": {
+          "version": "0.1.12",
+          "reason": "https://github.com/swc-project/swc/issues/9753"
+        }
+      },
       "undici": {
         "5.22.0": {
           "version": "5.21.2",


### PR DESCRIPTION
@swc/types@0.1.16

has no index.js, 是一个非兼容性改动, 降级到 0.1.12

---
同步雨燕改动内容

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated package dependencies for improved compatibility and security.
	- Added `@swc/types` package with version `0.1.16`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->