### PR TITLE
增加 @jridgewell/gen-mapping 模块的不可用版本替换逻辑

### DIFF
--- a/package.json
+++ b/package.json
@@ -1183,6 +1183,16 @@
           "version": "1.9.0",
           "reason": "https://github.com/pillarjs/path-to-regexp/security/advisories/GHSA-9wv6-86v2-598j"
         }
+      },
+      "@jridgewell/gen-mapping": {
+        "0.3.6": {
+          "version": "0.3.5",
+          "reason": "https://github.com/jridgewell/sourcemaps/issues/8"
+        },
+        "0.3.7": {
+          "version": "0.3.5",
+          "reason": "https://github.com/jridgewell/sourcemaps/issues/8"
+        }
       }
     }
   }


### PR DESCRIPTION
https://github.com/jridgewell/sourcemaps/issues/8 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new dependency for enhanced functionality: `@jridgewell/gen-mapping` with versions `0.3.6` and `0.3.7`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->