### PR TITLE
feat: nodejs january 2025 security releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # bug-versions
 
 [![NPM version][npm-image]][npm-url]
+[![CI](https://github.com/cnpm/bug-versions/actions/workflows/nodejs.yml/badge.svg?branch=master)](https://github.com/cnpm/bug-versions/actions/workflows/nodejs.yml)
 [![Known Vulnerabilities][snyk-image]][snyk-url]
 [![npm download][download-image]][download-url]
-[![Node.js CI][actions-image]][actions-url]
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://makeapullrequest.com)
 ![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/cnpm/bug-versions)
 
@@ -13,8 +13,6 @@
 [snyk-url]: https://snyk.io/test/npm/bug-versions
 [download-image]: https://img.shields.io/npm/dm/bug-versions.svg?style=flat-square
 [download-url]: https://npmjs.org/package/bug-versions
-[actions-image]: https://github.com/cnpm/bug-versions/workflows/Node.js%20CI/badge.svg
-[actions-url]: https://github.com/cnpm/bug-versions/actions
 
 collect all bug versions on npm package.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Known Vulnerabilities][snyk-image]][snyk-url]
 [![npm download][download-image]][download-url]
 [![Node.js CI][actions-image]][actions-url]
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square)](https://makeapullrequest.com)
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/cnpm/bug-versions)
 
 [npm-image]: https://img.shields.io/npm/v/bug-versions.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/bug-versions

--- a/package.json
+++ b/package.json
@@ -74,21 +74,25 @@
         "version": "16.20.2",
         "reason": "https://nodejs.org/en/blog/vulnerability/august-2023-security-releases"
       },
-      ">= 18.0.0 < 18.20.4": {
-        "version": "18.20.4",
-        "reason": "https://nodejs.org/en/blog/vulnerability/july-2024-security-releases"
+      ">= 18.0.0 < 18.20.6": {
+        "version": "18.20.6",
+        "reason": "https://nodejs.org/en/blog/vulnerability/january-2025-security-releases"
       },
-      ">= 20.0.0 < 20.15.1": {
-        "version": "20.15.1",
-        "reason": "https://nodejs.org/en/blog/vulnerability/july-2024-security-releases"
+      ">= 20.0.0 < 20.18.2": {
+        "version": "20.18.2",
+        "reason": "https://nodejs.org/en/blog/vulnerability/january-2025-security-releases"
       },
       ">= 21.0.0 < 21.7.2": {
         "version": "21.7.2",
         "reason": "https://nodejs.org/en/blog/vulnerability/april-2024-security-releases/"
       },
-      ">= 22.0.0 < 22.4.1": {
-        "version": "22.4.1",
-        "reason": "https://nodejs.org/en/blog/vulnerability/july-2024-security-releases"
+      ">= 22.0.0 < 22.13.1": {
+        "version": "22.13.1",
+        "reason": "https://nodejs.org/en/blog/vulnerability/january-2025-security-releases"
+      },
+      ">= 23.0.0 < 23.6.1": {
+        "version": "23.6.1",
+        "reason": "https://nodejs.org/en/blog/vulnerability/january-2025-security-releases"
       }
     },
     "unsafe-alinode-versions": {


### PR DESCRIPTION
closes https://github.com/cnpm/bug-versions/issues/264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added three new badges to README.md:
		- Continuous Integration badge
		- Pull requests welcome badge
		- CodeRabbit pull request reviews badge
	- Removed the previous Node.js CI badge

- **Chores**
	- Updated package.json with new Node.js version safety configurations
		- Updated unsafe version ranges for Node.js 18, 20, 22
		- Added new unsafe version range for Node.js 23
<!-- end of auto-generated comment: release notes by coderabbit.ai -->