### PR TITLE
feat: art-template@4.13.3 security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1241,6 +1241,12 @@
           "version": "1.1.8",
           "reason": "https://github.com/web-infra-dev/rspack/issues/8767#issuecomment-2552738907"
         }
+      },
+      "art-template": {
+        "4.13.3": {
+          "version": "4.13.2",
+          "reason": "https://github.com/goofychris/art-template/issues/660"
+        }
       }
     }
   }


### PR DESCRIPTION
> https://github.com/goofychris/art-template/issues/660
* 考虑到 art-template 依赖较多，先通过 bug-versions 指定版本

![image](https://github.com/user-attachments/assets/59cc9888-f5ec-4e46-a6b2-bf5142f978cc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated dependency configuration to recommend a stable version of a third-party template, mitigating issues associated with the newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->