### PR TITLE
feat: css-select@5.2.1 fallback to 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1267,6 +1267,12 @@
           "version": "6.1.0",
           "reason": "https://github.com/fb55/css-what/issues/1582"
         }
+      },
+      "css-select": {
+        "5.2.1": {
+          "version": "5.2.0",
+          "reason": "https://github.com/fb55/css-select/issues/1590"
+        }
       }
     }
   }


### PR DESCRIPTION
https://github.com/fb55/css-select/issues/1590

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the list of known problematic package versions to include "css-select" 5.2.1, recommending 5.2.0 as a safe alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->