### PR TITLE
feat: add chalk chalk-template supports-hyperlinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1366,6 +1366,24 @@
           "version": "0.2.2",
           "reason": "https://github.com/debug-js/debug/issues/1005"
         }
+      },
+      "chalk": {
+        "5.6.1": {
+          "version": "5.6.0",
+          "reason": "https://github.com/debug-js/debug/issues/1005"
+        }
+      },
+      "chalk-template": {
+        "1.1.1": {
+          "version": "1.1.0",
+          "reason": "https://github.com/debug-js/debug/issues/1005"
+        }
+      },
+      "supports-hyperlinks": {
+        "4.1.1": {
+          "version": "4.1.0",
+          "reason": "https://github.com/debug-js/debug/issues/1005"
+        }
       }
     }
   }


### PR DESCRIPTION
https://www.aikido.dev/blog/npm-debug-and-chalk-packages-compromised

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated dependency vulnerability redirect configuration for select packages to align patched versions (e.g., chalk 5.6.1→5.6.0, chalk-template 1.1.1→1.1.0, supports-hyperlinks 4.1.1→4.1.0).
  - Streamlines security reporting in tooling and maintains consistency across vulnerability references.
  - No changes to features, performance, or behavior; installation and usage remain unaffected.
  - Intended to improve maintenance and audit clarity without impacting end-user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->