### PR TITLE
feat: add antv-block list packages, default to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1650,6 +1650,2704 @@
           "version": "3.0.4",
           "reason": "https://socket.dev/blog/tinycolor-supply-chain-attack-affects-40-packages"
         }
+      },
+      "echarts-for-react": {
+        "3.0.7": {
+          "version": "3.0.6",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.1.7": {
+          "version": "3.0.6",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.2.7": {
+          "version": "3.0.6",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "size-sensor": {
+        "1.0.4": {
+          "version": "1.0.3",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.1.4": {
+          "version": "1.0.3",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.4": {
+          "version": "1.0.3",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6": {
+        "5.2.1": {
+          "version": "5.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "5.3.1": {
+          "version": "5.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g2": {
+        "5.5.8": {
+          "version": "5.4.8",
+          "reason": "antv-block list, default to latest"
+        },
+        "5.6.8": {
+          "version": "5.4.8",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f2": {
+        "5.15.0": {
+          "version": "5.14.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "5.16.0": {
+          "version": "5.14.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-react-components": {
+        "2.1.9": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.9": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6": {
+        "3.2.7": {
+          "version": "3.1.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.3.7": {
+          "version": "3.1.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-react-shape": {
+        "3.1.1": {
+          "version": "3.0.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.2.1": {
+          "version": "3.0.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "timeago.js": {
+        "4.1.2": {
+          "version": "4.0.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "4.2.2": {
+          "version": "4.0.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g2plot": {
+        "2.5.35": {
+          "version": "2.4.35",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.6.35": {
+          "version": "2.4.35",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-shader-components": {
+        "2.1.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g": {
+        "6.4.1": {
+          "version": "6.3.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "6.5.1": {
+          "version": "6.3.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/path-util": {
+        "3.1.1": {
+          "version": "3.0.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.2.1": {
+          "version": "3.0.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-math": {
+        "3.2.0": {
+          "version": "3.1.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.3.0": {
+          "version": "3.1.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/util": {
+        "3.4.11": {
+          "version": "3.3.11",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.5.11": {
+          "version": "3.3.11",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-control": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-3d": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-webgl": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-webgl-renderer": {
+        "1.1.26": {
+          "version": "1.0.26",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.26": {
+          "version": "1.0.26",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-dom-interaction": {
+        "2.2.31": {
+          "version": "2.1.31",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.31": {
+          "version": "2.1.31",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-html-renderer": {
+        "2.4.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.5.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g2-brush": {
+        "0.1.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/data-set": {
+        "0.12.8": {
+          "version": "0.11.8",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.13.8": {
+          "version": "0.11.8",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/attr": {
+        "0.4.5": {
+          "version": "0.3.5",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.5.5": {
+          "version": "0.3.5",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/component": {
+        "2.2.11": {
+          "version": "2.1.11",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.11": {
+          "version": "2.1.11",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/event-emitter": {
+        "0.2.3": {
+          "version": "0.1.3",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.3": {
+          "version": "0.1.3",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/scale": {
+        "0.6.2": {
+          "version": "0.5.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.7.2": {
+          "version": "0.5.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/adjust": {
+        "0.3.5": {
+          "version": "0.2.5",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.4.5": {
+          "version": "0.2.5",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/coord": {
+        "0.5.7": {
+          "version": "0.4.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.6.7": {
+          "version": "0.4.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/color-util": {
+        "2.1.6": {
+          "version": "2.0.6",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.6": {
+          "version": "2.0.6",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/matrix-util": {
+        "3.1.4": {
+          "version": "3.0.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.2.4": {
+          "version": "3.0.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-base": {
+        "0.6.16": {
+          "version": "0.5.16",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.7.16": {
+          "version": "0.5.16",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-svg": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-canvas": {
+        "2.3.0": {
+          "version": "2.2.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.4.0": {
+          "version": "2.2.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/xflow": {
+        "2.2.13": {
+          "version": "2.2.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.13": {
+          "version": "2.2.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-plugin": {
+        "0.9.25": {
+          "version": "0.8.25",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.10.25": {
+          "version": "0.8.25",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-element": {
+        "0.9.25": {
+          "version": "0.8.25",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.10.25": {
+          "version": "0.8.25",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/algorithm": {
+        "0.2.26": {
+          "version": "0.1.26",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.26": {
+          "version": "0.1.26",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/dom-util": {
+        "2.1.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-core": {
+        "0.9.24": {
+          "version": "0.8.24",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.10.24": {
+          "version": "0.8.24",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/hierarchy": {
+        "0.8.1": {
+          "version": "0.7.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.9.1": {
+          "version": "0.7.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-pc": {
+        "0.9.25": {
+          "version": "0.8.25",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.10.25": {
+          "version": "0.8.25",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-webgpu": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-editor": {
+        "1.3.0": {
+          "version": "1.2.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.4.0": {
+          "version": "1.2.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f2-my": {
+        "4.1.52": {
+          "version": "4.0.52",
+          "reason": "antv-block list, default to latest"
+        },
+        "4.2.52": {
+          "version": "4.0.52",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f2-react": {
+        "5.15.0": {
+          "version": "5.14.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "5.16.0": {
+          "version": "5.14.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-layers": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-maps": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/s2": {
+        "2.8.1": {
+          "version": "2.7.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.9.1": {
+          "version": "2.7.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/s2-react": {
+        "2.4.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.5.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-map": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/dipper-map": {
+        "1.1.10": {
+          "version": "1.0.10",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.10": {
+          "version": "1.0.10",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-core": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-renderer": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-utils": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-component": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-mini": {
+        "2.21.8": {
+          "version": "2.20.8",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.22.8": {
+          "version": "2.20.8",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-source": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-vue-shape": {
+        "3.1.2": {
+          "version": "3.0.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.2.2": {
+          "version": "3.0.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-scene": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-three": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-plugins": {
+        "1.1.9": {
+          "version": "1.0.9",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.9": {
+          "version": "1.0.9",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/async-hook": {
+        "2.3.9": {
+          "version": "2.2.9",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.4.9": {
+          "version": "2.2.9",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/geo-coord": {
+        "1.1.8": {
+          "version": "1.0.8",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.8": {
+          "version": "1.0.8",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "timeago-react": {
+        "3.1.7": {
+          "version": "3.0.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.2.7": {
+          "version": "3.0.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/xflow-hook": {
+        "1.1.55": {
+          "version": "2.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.55": {
+          "version": "2.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/xflow-core": {
+        "1.1.55": {
+          "version": "2.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.55": {
+          "version": "2.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/xflow-extension": {
+        "1.1.55": {
+          "version": "2.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.55": {
+          "version": "2.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/narrative-text-vis": {
+        "0.4.16": {
+          "version": "0.3.16",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.5.16": {
+          "version": "0.3.16",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g2-plugin-slider": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/my-f2": {
+        "2.2.7": {
+          "version": "2.1.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.7": {
+          "version": "2.1.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f2-context": {
+        "0.1.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7plot": {
+        "0.6.11": {
+          "version": "0.5.11",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.7.11": {
+          "version": "0.5.11",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/dw-analyzer": {
+        "1.2.5": {
+          "version": "1.1.5",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.5": {
+          "version": "1.1.5",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/dw-random": {
+        "1.2.7": {
+          "version": "1.1.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.7": {
+          "version": "1.1.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/dw-transform": {
+        "1.2.7": {
+          "version": "1.1.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.7": {
+          "version": "1.1.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-gesture": {
+        "3.1.42": {
+          "version": "3.0.42",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.2.42": {
+          "version": "3.0.42",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-perf": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-webgpu-core": {
+        "0.8.2": {
+          "version": "0.7.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.9.2": {
+          "version": "0.7.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-webgpu-engine": {
+        "0.8.2": {
+          "version": "0.7.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.9.2": {
+          "version": "0.7.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gl-matrix": {
+        "2.8.1": {
+          "version": "2.7.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.9.1": {
+          "version": "2.7.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/interaction": {
+        "0.2.5": {
+          "version": "0.1.5",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.5": {
+          "version": "0.1.5",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gatsby-theme": {
+        "0.2.0": {
+          "version": "0.1.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.0": {
+          "version": "0.1.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/istanbul": {
+        "0.1.0": {
+          "version": "0.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.0": {
+          "version": "0.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/calendar-heatmap": {
+        "1.2.2": {
+          "version": "1.1.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.2": {
+          "version": "1.1.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-components": {
+        "0.11.7": {
+          "version": "0.10.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.12.7": {
+          "version": "0.10.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/stat": {
+        "0.1.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/my-f2-pc": {
+        "0.2.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f2-canvas": {
+        "1.1.5": {
+          "version": "1.0.5",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.5": {
+          "version": "1.0.5",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/torch": {
+        "1.1.6": {
+          "version": "1.0.6",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.6": {
+          "version": "1.0.6",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/thumbnails": {
+        "2.1.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/knowledge": {
+        "1.2.4": {
+          "version": "1.1.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.4": {
+          "version": "1.1.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/graphin-components": {
+        "2.5.1": {
+          "version": "2.4.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.6.1": {
+          "version": "2.4.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/chart-node-g6": {
+        "0.1.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/graphin": {
+        "3.1.5": {
+          "version": "3.0.5",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.2.5": {
+          "version": "3.0.5",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/wx-f2": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-district": {
+        "2.4.12": {
+          "version": "2.3.12",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.5.12": {
+          "version": "2.3.12",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-react": {
+        "2.5.3": {
+          "version": "2.4.3",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.6.3": {
+          "version": "2.4.3",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-draw": {
+        "3.2.5": {
+          "version": "3.1.5",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.3.5": {
+          "version": "3.1.5",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/graphin-icons": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-webgpu-raytracer": {
+        "0.6.1": {
+          "version": "0.6.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.7.1": {
+          "version": "0.6.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-webgpu-unitchart": {
+        "0.6.1": {
+          "version": "0.6.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.7.1": {
+          "version": "0.6.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/vis-predict-engine": {
+        "0.2.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g2plot-schemas": {
+        "1.3.2": {
+          "version": "1.2.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.4.2": {
+          "version": "1.2.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/graphin-graphscope": {
+        "1.1.5": {
+          "version": "1.0.5",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.5": {
+          "version": "1.0.5",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-react-node": {
+        "1.5.8": {
+          "version": "1.4.8",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.6.8": {
+          "version": "1.4.8",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-vue3-shape": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-mobile": {
+        "1.2.5": {
+          "version": "1.1.5",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.5": {
+          "version": "1.1.5",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/data-samples": {
+        "1.1.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-vector": {
+        "1.5.2": {
+          "version": "1.4.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.6.2": {
+          "version": "1.4.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-geometry": {
+        "2.1.5": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.5": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/dw-util": {
+        "1.2.4": {
+          "version": "1.1.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.4": {
+          "version": "1.1.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-alipay": {
+        "0.1.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-wx": {
+        "0.1.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/chart-linter": {
+        "1.2.6": {
+          "version": "1.1.6",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.6": {
+          "version": "1.1.6",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f6-alipay": {
+        "0.1.7": {
+          "version": "0.0.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.7": {
+          "version": "0.0.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f6-wx": {
+        "0.1.7": {
+          "version": "0.0.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.7": {
+          "version": "0.0.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f6": {
+        "0.1.19": {
+          "version": "0.0.19",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.19": {
+          "version": "0.0.19",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f6-element": {
+        "0.1.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f6-core": {
+        "0.1.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-canvas-picker": {
+        "2.4.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.5.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-svg-picker": {
+        "2.1.46": {
+          "version": "2.0.46",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.46": {
+          "version": "2.0.46",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-svg-renderer": {
+        "2.5.1": {
+          "version": "2.4.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.6.1": {
+          "version": "2.4.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-canvas-renderer": {
+        "2.6.1": {
+          "version": "2.5.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.7.1": {
+          "version": "2.5.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/smart-color": {
+        "0.3.1": {
+          "version": "0.2.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.4.1": {
+          "version": "0.2.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/color-schema": {
+        "0.3.3": {
+          "version": "0.2.3",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.4.3": {
+          "version": "0.2.3",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f6-ui": {
+        "1.1.3": {
+          "version": "1.0.3",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.3": {
+          "version": "1.0.3",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f6-plugin": {
+        "1.1.6": {
+          "version": "1.0.6",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.6": {
+          "version": "1.0.6",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7plot-component": {
+        "0.1.11": {
+          "version": "0.0.11",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.11": {
+          "version": "0.0.11",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/dipper-component": {
+        "0.1.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f2-graphic": {
+        "0.1.16": {
+          "version": "0.0.16",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.16": {
+          "version": "0.0.16",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/thumbnails-component": {
+        "2.1.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/ckb": {
+        "2.1.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/data-wizard": {
+        "2.1.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/lite-insight": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-mobile": {
+        "0.2.2": {
+          "version": "0.1.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.2": {
+          "version": "0.1.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/react-g": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/dipper-hooks": {
+        "0.3.1": {
+          "version": "0.2.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.4.1": {
+          "version": "0.2.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/word-scale-chart": {
+        "0.4.4": {
+          "version": "0.3.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.5.4": {
+          "version": "0.3.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/narrative-text-schema": {
+        "0.4.7": {
+          "version": "0.3.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.5.7": {
+          "version": "0.3.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-pass": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/webgpu-graph": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f6-hammerjs": {
+        "0.1.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-matterjs": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-yoga": {
+        "2.4.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.5.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/graphlib": {
+        "2.1.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-mobile-interaction": {
+        "1.1.42": {
+          "version": "1.0.42",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.42": {
+          "version": "1.0.42",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-common": {
+        "2.1.17": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.17": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/dumi-theme-antv": {
+        "0.9.4": {
+          "version": "0.8.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.10.4": {
+          "version": "0.8.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-mobile-canvas": {
+        "1.2.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-mobile-svg": {
+        "1.2.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-mobile-webgl": {
+        "1.2.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/narrative-text-editor": {
+        "0.3.20": {
+          "version": "0.2.20",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.4.20": {
+          "version": "0.2.20",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-rough-svg-renderer": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-rough-canvas-renderer": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-webgl-device": {
+        "1.10.17": {
+          "version": "1.9.17",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.11.17": {
+          "version": "1.9.17",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-device-renderer": {
+        "2.7.1": {
+          "version": "2.6.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.8.1": {
+          "version": "2.6.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-composite-layers": {
+        "0.18.1": {
+          "version": "0.17.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.19.1": {
+          "version": "0.17.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-dragndrop": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/larkmap": {
+        "1.6.1": {
+          "version": "1.5.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.7.1": {
+          "version": "1.5.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f-engine": {
+        "1.11.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.12.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-mobile-canvas-element": {
+        "1.1.42": {
+          "version": "1.0.42",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.42": {
+          "version": "1.0.42",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/s2-vue": {
+        "2.3.0": {
+          "version": "2.2.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.4.0": {
+          "version": "2.2.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-canvaskit": {
+        "1.2.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-image-loader": {
+        "2.4.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.5.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-canvas-path-generator": {
+        "2.2.26": {
+          "version": "2.1.26",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.26": {
+          "version": "2.1.26",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-image-exporter": {
+        "1.1.42": {
+          "version": "1.0.42",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.42": {
+          "version": "1.0.42",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f-charts": {
+        "0.1.0": {
+          "version": "0.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.0": {
+          "version": "0.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-a11y": {
+        "1.5.1": {
+          "version": "1.4.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.6.1": {
+          "version": "1.4.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-annotation": {
+        "1.3.0": {
+          "version": "1.2.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.4.0": {
+          "version": "1.2.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-lite": {
+        "2.8.0": {
+          "version": "2.7.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.9.0": {
+          "version": "2.7.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-plugin-scroller": {
+        "2.1.10": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.10": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-plugin-keyboard": {
+        "2.3.3": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.4.3": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-leaflet": {
+        "1.1.2": {
+          "version": "1.0.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.2": {
+          "version": "1.0.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-camera-api": {
+        "2.1.45": {
+          "version": "2.0.45",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.45": {
+          "version": "2.0.45",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-css-typed-om-api": {
+        "1.1.38": {
+          "version": "1.0.38",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.38": {
+          "version": "1.0.38",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-compat": {
+        "1.1.11": {
+          "version": "1.0.11",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.11": {
+          "version": "1.0.11",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-dom-mutation-observer-api": {
+        "2.1.42": {
+          "version": "2.0.42",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.42": {
+          "version": "2.0.42",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-css-layout-api": {
+        "1.1.38": {
+          "version": "1.0.38",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.38": {
+          "version": "1.0.38",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-web-animations-api": {
+        "2.2.32": {
+          "version": "2.1.32",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.32": {
+          "version": "2.1.32",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-lottie-player": {
+        "1.2.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f-my": {
+        "1.11.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.12.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f-react": {
+        "1.11.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.12.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f-vue": {
+        "1.11.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.12.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-plugin-selection": {
+        "2.3.2": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.4.2": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-plugin-snapline": {
+        "2.2.7": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.7": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/insight-component": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-plugin-clipboard": {
+        "2.2.6": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.6": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-plugin-dnd": {
+        "2.2.1": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f-wx": {
+        "1.11.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.12.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f-lottie": {
+        "1.11.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.12.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-sdk": {
+        "3.1.0": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.2.0": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-plugin-export": {
+        "2.2.6": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.6": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-plugin-minimap": {
+        "2.1.7": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.7": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-plugin-history": {
+        "2.3.4": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.4.4": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-plugin-transform": {
+        "2.2.8": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.8": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/x6-plugin-stencil": {
+        "2.2.5": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.5": {
+          "version": "3.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-theme-antd": {
+        "0.7.11": {
+          "version": "0.6.11",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.8.11": {
+          "version": "0.6.11",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-common-components": {
+        "1.4.16": {
+          "version": "1.3.16",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.5.16": {
+          "version": "1.3.16",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-assets-basic": {
+        "2.5.40": {
+          "version": "2.4.40",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.6.40": {
+          "version": "2.4.40",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-assets-advance": {
+        "2.6.22": {
+          "version": "2.5.22",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.7.22": {
+          "version": "2.5.22",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-assets-algorithm": {
+        "2.4.19": {
+          "version": "2.3.19",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.5.19": {
+          "version": "2.3.19",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-assets-scene": {
+        "2.3.21": {
+          "version": "2.2.21",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.4.21": {
+          "version": "2.2.21",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-assets-graphscope": {
+        "2.2.15": {
+          "version": "2.1.15",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.15": {
+          "version": "2.1.15",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-assets-tugraph": {
+        "2.2.15": {
+          "version": "2.1.15",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.15": {
+          "version": "2.1.15",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-assets-neo4j": {
+        "2.2.15": {
+          "version": "2.1.15",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.15": {
+          "version": "2.1.15",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-pattern": {
+        "2.1.42": {
+          "version": "2.0.42",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.2.42": {
+          "version": "2.0.42",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/ava": {
+        "3.5.1": {
+          "version": "3.4.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.6.1": {
+          "version": "3.4.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/ava-react": {
+        "3.4.2": {
+          "version": "3.3.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "3.5.2": {
+          "version": "3.3.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-cli": {
+        "1.3.11": {
+          "version": "1.2.11",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.4.11": {
+          "version": "1.2.11",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/li-sdk": {
+        "1.6.1": {
+          "version": "1.5.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.7.1": {
+          "version": "1.5.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/li-editor": {
+        "1.7.1": {
+          "version": "1.6.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.8.1": {
+          "version": "1.6.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/li-core-assets": {
+        "1.4.7": {
+          "version": "1.3.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.5.7": {
+          "version": "1.3.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/li-analysis-assets": {
+        "1.10.1": {
+          "version": "1.9.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.11.1": {
+          "version": "1.9.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-zdog-canvas-renderer": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-zdog-svg-renderer": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-mock-data": {
+        "1.1.5": {
+          "version": "1.0.5",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.5": {
+          "version": "1.0.5",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/layout-wasm": {
+        "1.5.2": {
+          "version": "1.4.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.6.2": {
+          "version": "1.4.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/d3-interpolate": {
+        "1.1.3": {
+          "version": "1.0.3",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.3": {
+          "version": "1.0.3",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/d3-color": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/layout-gpu": {
+        "1.2.7": {
+          "version": "1.1.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.7": {
+          "version": "1.1.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f-test-utils": {
+        "1.1.9": {
+          "version": "1.0.9",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.9": {
+          "version": "1.0.9",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f2-wordcloud": {
+        "5.15.0": {
+          "version": "5.14.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "5.16.0": {
+          "version": "5.14.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-assets-hugegraph": {
+        "1.2.15": {
+          "version": "1.1.15",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.15": {
+          "version": "1.1.15",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-assets-galaxybase": {
+        "1.3.15": {
+          "version": "1.2.15",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.4.15": {
+          "version": "1.2.15",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/li-p2": {
+        "1.9.2": {
+          "version": "1.8.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.10.2": {
+          "version": "1.8.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/sam": {
+        "0.3.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.4.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-assets-janusgraph": {
+        "1.2.15": {
+          "version": "1.1.15",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.15": {
+          "version": "1.1.15",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-assets-tugraph-analytics": {
+        "0.3.15": {
+          "version": "0.2.15",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.4.15": {
+          "version": "0.2.15",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/semantic-release-pnpm": {
+        "1.1.4": {
+          "version": "1.0.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.4": {
+          "version": "1.0.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/li-aiearth-assets": {
+        "0.5.7": {
+          "version": "0.4.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.6.7": {
+          "version": "0.4.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/li-sam-assets": {
+        "0.2.4": {
+          "version": "0.1.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.4": {
+          "version": "0.1.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-sdk-app": {
+        "1.3.10": {
+          "version": "1.2.10",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.4.10": {
+          "version": "1.2.10",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-assets-xlab": {
+        "0.2.30": {
+          "version": "0.1.30",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.30": {
+          "version": "0.1.30",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gi-public-data": {
+        "1.1.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-editor": {
+        "1.2.13": {
+          "version": "1.1.13",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.3.13": {
+          "version": "1.1.13",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-plugin-gesture": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/f2-algorithm": {
+        "5.8.0": {
+          "version": "5.7.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "5.9.0": {
+          "version": "5.7.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-device-api": {
+        "1.7.13": {
+          "version": "1.6.13",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.8.13": {
+          "version": "1.6.13",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/translator": {
+        "1.1.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g-webgl-compute": {
+        "0.1.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-plugin-map-view": {
+        "0.1.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g2-extension-ava": {
+        "0.3.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.4.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g2-extension-3d": {
+        "0.3.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.4.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/xflow-diff": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/a8": {
+        "0.1.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-extension-g-layer": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g2-extension-plot": {
+        "0.3.2": {
+          "version": "0.2.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.4.2": {
+          "version": "0.2.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-extension-react": {
+        "0.3.7": {
+          "version": "0.2.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.4.7": {
+          "version": "0.2.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-extension-3d": {
+        "0.2.23": {
+          "version": "0.1.23",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.23": {
+          "version": "0.1.23",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-cli": {
+        "0.1.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gpt-vis": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/s2-react-components": {
+        "2.2.2": {
+          "version": "2.1.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "2.3.2": {
+          "version": "2.1.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g6-ssr": {
+        "0.2.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/g2-ssr": {
+        "0.3.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.4.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/awards": {
+        "0.1.9": {
+          "version": "0.0.9",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.2.9": {
+          "version": "0.0.9",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/vendor": {
+        "1.1.11": {
+          "version": "1.0.11",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.11": {
+          "version": "1.0.11",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/github-config-cli": {
+        "0.2.0": {
+          "version": "0.1.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.0": {
+          "version": "0.1.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/expr": {
+        "1.1.2": {
+          "version": "1.0.2",
+          "reason": "antv-block list, default to latest"
+        },
+        "1.2.2": {
+          "version": "1.0.2",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/gpt-vis-ssr": {
+        "0.4.7": {
+          "version": "0.3.7",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.5.7": {
+          "version": "0.3.7",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/mcp-server-chart": {
+        "0.10.10": {
+          "version": "0.9.10",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.11.10": {
+          "version": "0.9.10",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/t8": {
+        "0.4.0": {
+          "version": "0.3.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.5.0": {
+          "version": "0.3.0",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "mcp-echarts": {
+        "0.8.1": {
+          "version": "0.7.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.9.1": {
+          "version": "0.7.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/mcp-server-antv": {
+        "0.2.8": {
+          "version": "0.1.8",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.8": {
+          "version": "0.1.8",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/infographic": {
+        "0.3.19": {
+          "version": "0.2.19",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.4.19": {
+          "version": "0.2.19",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/s2-ssr": {
+        "0.2.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/chart-visualization-skills": {
+        "0.2.3": {
+          "version": "0.1.3",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.3.3": {
+          "version": "0.1.3",
+          "reason": "antv-block list, default to latest"
+        }
+      },
+      "@antv/l7-mapkit": {
+        "0.6.0": {
+          "version": "0.5.0",
+          "reason": "antv-block list, default to latest"
+        },
+        "0.7.0": {
+          "version": "0.5.0",
+          "reason": "antv-block list, default to latest"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

This PR ingests the antv-block source list (an Excel sheet, `执行结果5.xlsx`, 638 rows across 318 packages) into `config["bug-versions"]` in `package.json`.

For each `(scope, name)` in the source, every listed version is added as a redirect key under `config["bug-versions"][pkg]`, pointing at that package's current canonical "latest" dist-tag. The intent is that any consumer who asks for one of the listed older-or-misbehaving versions resolves forward to whatever the canonical latest is at the time of this ingest. Each entry's `reason` field is the static string `"antv-block list, default to latest"`.

**Numbers after the merge**

| metric | before | after |
|---|---|---|
| top-level packages under `config["bug-versions"]` | 180 | 449 |
| total redirect entries (the `node --test` "bug versions" count) | 286 | 826 |

Added by this PR: **269 packages, 540 redirect entries**.

**Why 269 and not 318**

49 packages in the source list don't get an entry, because their current canonical "latest" is itself flagged as upstream-unavailable (the registry that publishes the canonical "latest" tag returns `HTTP 451 Unavailable For Legal Reasons` for each of them, with a body saying the tagged version was "blocked" by upstream admission policy). With no canonical target version, there is no safe redirect to write, so the entire package is omitted. The 49 skipped packages, sorted: `@antv/f2-site`, `@antv/f2-vue`, `@antv/f2-wx`, `@antv/g-components`, `@antv/g-layout-blocklike`, `@antv/g-plugin-box2d`, `@antv/g-plugin-canvaskit-renderer`, `@antv/g-plugin-css-select`, `@antv/g-plugin-gpgpu`, `@antv/g-plugin-physx`, `@antv/g-plugin-webgpu-device`, `@antv/g-web-components`, `@antv/g-webgpu-compiler`, `@antv/g6-lite`, `@antv/x6-angular-shape`, `@antv/x6-react`, `@lint-md/cli`, `@lint-md/core`, `@lint-md/parser`, `ai-figure`, `amapcn`, `ast-plugin`, `babel-plugin-version`, `boring-avatars-vanilla`, `byte-parser`, `canvas-nest.js`, `filesize.js`, `fixed-round`, `gantt-for-react`, `jest-canvas-mock`, `jest-date-mock`, `jest-electron`, `jest-expect`, `jest-less-loader`, `jest-random-mock`, `jest-url-loader`, `limit-size`, `lint-md`, `lint-md-cli`, `mcp-mermaid`, `miz`, `onfire.js`, `react-adsense`, `relationship.js`, `ribbon.js`, `slice.js`, `uri-parse`, `word-width`, `xmorse`.

The 269 surviving packages have zero name overlap with the existing 180 top-level keys, so nothing pre-existing is modified. The previously-noted "singletons" `ribbon.js@1.1.2` and `@antv/g6-lite@0.1.0-beta.1` happen to fall inside this 49-skip set (the canonical-latest lookup says their latest is unpublishable), so they remain out of the file.

## Test plan

- [x] `node --test` passes locally — both subtests in `test/index.test.js` succeed and the test prints `Total: 449 bug pkgs and 826 bug versions`.
- [x] A standalone duplicate-key scan over the raw text of `package.json` (top-level + nested object scopes) reports zero collisions. The 269 newly-added top-level keys are all fresh.
- [x] The 540 added inner version-keys are unique within their containing package (the ingester deduplicates within a `(scope, name)` group).
- [ ] CI's `find-duplicated-property-keys -s package.json` step succeeds in the `nodejs.yml` workflow.
- [ ] CI's commitlint PR-title check passes — the title uses the conventional-commit `feat:` prefix the angular config expects.

## History

The first push of this branch (commit `4a3ce84`) implemented a different and incorrect rule: it picked the highest semver in each xlsx group as the redirect target. The correct rule is "redirect to the canonical latest dist-tag of the package," which is what is now in the branch. The branch was force-pushed (`--force-with-lease`) with the corrected single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version configurations to improve stability and compatibility with visualization libraries and related dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cnpm/bug-versions/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->