### PR TITLE
feat: add antv-block incident block list for 317 packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1650,6 +1650,3188 @@
           "version": "3.0.4",
           "reason": "https://socket.dev/blog/tinycolor-supply-chain-attack-affects-40-packages"
         }
+      },
+      "@antv/a8": {
+        "0.1.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/adjust": {
+        "0.3.5": {
+          "version": "0.2.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.5": {
+          "version": "0.2.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/algorithm": {
+        "0.2.26": {
+          "version": "0.1.26",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.26": {
+          "version": "0.1.26",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/async-hook": {
+        "2.3.9": {
+          "version": "2.2.9",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.4.9": {
+          "version": "2.2.9",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/attr": {
+        "0.4.5": {
+          "version": "0.3.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.5.5": {
+          "version": "0.3.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/ava": {
+        "3.5.1": {
+          "version": "3.4.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.6.1": {
+          "version": "3.4.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/ava-react": {
+        "3.4.2": {
+          "version": "3.3.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.5.2": {
+          "version": "3.3.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/awards": {
+        "0.1.9": {
+          "version": "0.0.9",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.9": {
+          "version": "0.0.9",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/calendar-heatmap": {
+        "1.2.2": {
+          "version": "1.1.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.2": {
+          "version": "1.1.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/chart-linter": {
+        "1.2.6": {
+          "version": "1.1.6",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.6": {
+          "version": "1.1.6",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/chart-node-g6": {
+        "0.1.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/chart-visualization-skills": {
+        "0.2.3": {
+          "version": "0.1.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.3": {
+          "version": "0.1.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/ckb": {
+        "2.1.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/color-schema": {
+        "0.3.3": {
+          "version": "0.2.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.3": {
+          "version": "0.2.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/color-util": {
+        "2.1.6": {
+          "version": "2.0.6",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.6": {
+          "version": "2.0.6",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/component": {
+        "2.2.11": {
+          "version": "2.1.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.11": {
+          "version": "2.1.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/coord": {
+        "0.5.7": {
+          "version": "0.4.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.6.7": {
+          "version": "0.4.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/d3-color": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/d3-interpolate": {
+        "1.1.3": {
+          "version": "1.0.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.3": {
+          "version": "1.0.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/data-samples": {
+        "1.1.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/data-set": {
+        "0.12.8": {
+          "version": "0.11.8",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.13.8": {
+          "version": "0.11.8",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/data-wizard": {
+        "2.1.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/dipper-component": {
+        "0.1.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/dipper-hooks": {
+        "0.3.1": {
+          "version": "0.2.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.1": {
+          "version": "0.2.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/dipper-map": {
+        "1.1.10": {
+          "version": "1.0.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.10": {
+          "version": "1.0.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/dom-util": {
+        "2.1.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/dumi-theme-antv": {
+        "0.10.4": {
+          "version": "0.8.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.9.4": {
+          "version": "0.8.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/dw-analyzer": {
+        "1.2.5": {
+          "version": "1.1.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.5": {
+          "version": "1.1.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/dw-random": {
+        "1.2.7": {
+          "version": "1.1.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.7": {
+          "version": "1.1.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/dw-transform": {
+        "1.2.7": {
+          "version": "1.1.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.7": {
+          "version": "1.1.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/dw-util": {
+        "1.2.4": {
+          "version": "1.1.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.4": {
+          "version": "1.1.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/event-emitter": {
+        "0.2.3": {
+          "version": "0.1.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.3": {
+          "version": "0.1.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/expr": {
+        "1.1.2": {
+          "version": "1.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.2": {
+          "version": "1.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f-charts": {
+        "0.1.0": {
+          "version": "0.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.0": {
+          "version": "0.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f-engine": {
+        "1.11.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.12.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f-lottie": {
+        "1.11.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.12.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f-my": {
+        "1.11.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.12.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f-react": {
+        "1.11.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.12.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f-test-utils": {
+        "1.1.9": {
+          "version": "1.0.9",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.9": {
+          "version": "1.0.9",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f-vue": {
+        "1.11.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.12.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f-wx": {
+        "1.11.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.12.0": {
+          "version": "1.10.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f2": {
+        "5.15.0": {
+          "version": "5.14.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "5.16.0": {
+          "version": "5.14.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f2-algorithm": {
+        "5.8.0": {
+          "version": "5.7.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "5.9.0": {
+          "version": "5.7.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f2-canvas": {
+        "1.1.5": {
+          "version": "1.0.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.5": {
+          "version": "1.0.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f2-context": {
+        "0.1.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f2-graphic": {
+        "0.1.16": {
+          "version": "0.0.16",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.16": {
+          "version": "0.0.16",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f2-my": {
+        "4.1.52": {
+          "version": "4.0.52",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "4.2.52": {
+          "version": "4.0.52",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f2-react": {
+        "5.15.0": {
+          "version": "5.14.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "5.16.0": {
+          "version": "5.14.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f2-site": {
+        "4.1.42": {
+          "version": "4.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "4.2.42": {
+          "version": "4.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f2-vue": {
+        "4.1.33": {
+          "version": "4.0.33",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "4.2.33": {
+          "version": "4.0.33",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f2-wordcloud": {
+        "5.15.0": {
+          "version": "5.14.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "5.16.0": {
+          "version": "5.14.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f2-wx": {
+        "4.1.51": {
+          "version": "4.0.51",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "4.2.51": {
+          "version": "4.0.51",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f6": {
+        "0.1.19": {
+          "version": "0.0.19",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.19": {
+          "version": "0.0.19",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f6-alipay": {
+        "0.1.7": {
+          "version": "0.0.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.7": {
+          "version": "0.0.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f6-core": {
+        "0.1.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f6-element": {
+        "0.1.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f6-hammerjs": {
+        "0.1.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f6-plugin": {
+        "1.1.6": {
+          "version": "1.0.6",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.6": {
+          "version": "1.0.6",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f6-ui": {
+        "1.1.3": {
+          "version": "1.0.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.3": {
+          "version": "1.0.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/f6-wx": {
+        "0.1.7": {
+          "version": "0.0.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.7": {
+          "version": "0.0.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g": {
+        "6.4.1": {
+          "version": "6.3.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "6.5.1": {
+          "version": "6.3.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-base": {
+        "0.6.16": {
+          "version": "0.5.16",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.7.16": {
+          "version": "0.5.16",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-camera-api": {
+        "2.1.45": {
+          "version": "2.0.45",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.45": {
+          "version": "2.0.45",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-canvas": {
+        "2.3.0": {
+          "version": "2.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.4.0": {
+          "version": "2.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-canvaskit": {
+        "1.2.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-compat": {
+        "1.1.11": {
+          "version": "1.0.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.11": {
+          "version": "1.0.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-components": {
+        "2.1.42": {
+          "version": "2.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.42": {
+          "version": "2.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-css-layout-api": {
+        "1.1.38": {
+          "version": "1.0.38",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.38": {
+          "version": "1.0.38",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-css-typed-om-api": {
+        "1.1.38": {
+          "version": "1.0.38",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.38": {
+          "version": "1.0.38",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-device-api": {
+        "1.7.13": {
+          "version": "1.6.13",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.8.13": {
+          "version": "1.6.13",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-dom-mutation-observer-api": {
+        "2.1.42": {
+          "version": "2.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.42": {
+          "version": "2.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-gesture": {
+        "3.1.42": {
+          "version": "3.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.2.42": {
+          "version": "3.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-image-exporter": {
+        "1.1.42": {
+          "version": "1.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.42": {
+          "version": "1.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-layout-blocklike": {
+        "1.8.49": {
+          "version": "1.7.49",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.9.49": {
+          "version": "1.7.49",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-lite": {
+        "2.8.0": {
+          "version": "2.7.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.9.0": {
+          "version": "2.7.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-lottie-player": {
+        "1.2.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-math": {
+        "3.2.0": {
+          "version": "3.1.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.3.0": {
+          "version": "3.1.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-mobile": {
+        "1.2.5": {
+          "version": "1.1.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.5": {
+          "version": "1.1.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-mobile-canvas": {
+        "1.2.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-mobile-canvas-element": {
+        "1.1.42": {
+          "version": "1.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.42": {
+          "version": "1.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-mobile-svg": {
+        "1.2.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-mobile-webgl": {
+        "1.2.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-pattern": {
+        "2.1.42": {
+          "version": "2.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.42": {
+          "version": "2.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-perf": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-3d": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-a11y": {
+        "1.5.1": {
+          "version": "1.4.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.6.1": {
+          "version": "1.4.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-annotation": {
+        "1.3.0": {
+          "version": "1.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.4.0": {
+          "version": "1.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-box2d": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-canvas-path-generator": {
+        "2.2.26": {
+          "version": "2.1.26",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.26": {
+          "version": "2.1.26",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-canvas-picker": {
+        "2.4.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.5.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-canvas-renderer": {
+        "2.6.1": {
+          "version": "2.5.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.7.1": {
+          "version": "2.5.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-canvaskit-renderer": {
+        "2.4.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.5.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-control": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-css-select": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-device-renderer": {
+        "2.7.1": {
+          "version": "2.6.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.8.1": {
+          "version": "2.6.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-dom-interaction": {
+        "2.2.31": {
+          "version": "2.1.31",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.31": {
+          "version": "2.1.31",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-dragndrop": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-gesture": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-gpgpu": {
+        "1.10.20": {
+          "version": "1.9.20",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.11.20": {
+          "version": "1.9.20",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-html-renderer": {
+        "2.4.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.5.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-image-loader": {
+        "2.4.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.5.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-matterjs": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-mobile-interaction": {
+        "1.1.42": {
+          "version": "1.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.42": {
+          "version": "1.0.42",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-physx": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-rough-canvas-renderer": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-rough-svg-renderer": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-svg-picker": {
+        "2.1.46": {
+          "version": "2.0.46",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.46": {
+          "version": "2.0.46",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-svg-renderer": {
+        "2.5.1": {
+          "version": "2.4.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.6.1": {
+          "version": "2.4.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-webgl-device": {
+        "1.10.17": {
+          "version": "1.9.17",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.11.17": {
+          "version": "1.9.17",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-webgl-renderer": {
+        "1.1.26": {
+          "version": "1.0.26",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.26": {
+          "version": "1.0.26",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-webgpu-device": {
+        "1.10.17": {
+          "version": "1.9.17",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.11.17": {
+          "version": "1.9.17",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-yoga": {
+        "2.4.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.5.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-zdog-canvas-renderer": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-plugin-zdog-svg-renderer": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-shader-components": {
+        "2.1.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-svg": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-web-animations-api": {
+        "2.2.32": {
+          "version": "2.1.32",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.32": {
+          "version": "2.1.32",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-web-components": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-webgl": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-webgl-compute": {
+        "0.1.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-webgpu": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-webgpu-compiler": {
+        "0.8.2": {
+          "version": "1.0.21",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.9.2": {
+          "version": "1.0.21",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-webgpu-core": {
+        "0.8.2": {
+          "version": "0.7.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.9.2": {
+          "version": "0.7.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-webgpu-engine": {
+        "0.8.2": {
+          "version": "0.7.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.9.2": {
+          "version": "0.7.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-webgpu-raytracer": {
+        "0.6.1": {
+          "version": "0.6.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.7.1": {
+          "version": "0.6.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g-webgpu-unitchart": {
+        "0.6.1": {
+          "version": "0.6.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.7.1": {
+          "version": "0.6.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g2": {
+        "5.5.8": {
+          "version": "5.4.8",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "5.6.8": {
+          "version": "5.4.8",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g2-brush": {
+        "0.1.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g2-extension-3d": {
+        "0.3.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g2-extension-ava": {
+        "0.3.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g2-extension-plot": {
+        "0.3.2": {
+          "version": "0.2.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.2": {
+          "version": "0.2.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g2-plugin-slider": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g2-ssr": {
+        "0.3.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g2plot": {
+        "2.5.35": {
+          "version": "2.4.35",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.6.35": {
+          "version": "2.4.35",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g2plot-schemas": {
+        "1.3.2": {
+          "version": "1.2.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.4.2": {
+          "version": "1.2.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6": {
+        "5.2.1": {
+          "version": "5.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "5.3.1": {
+          "version": "5.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-alipay": {
+        "0.1.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-cli": {
+        "0.1.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-core": {
+        "0.10.24": {
+          "version": "0.8.24",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.9.24": {
+          "version": "0.8.24",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-editor": {
+        "1.3.0": {
+          "version": "1.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.4.0": {
+          "version": "1.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-element": {
+        "0.10.25": {
+          "version": "0.8.25",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.9.25": {
+          "version": "0.8.25",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-extension-3d": {
+        "0.2.23": {
+          "version": "0.1.23",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.23": {
+          "version": "0.1.23",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-extension-react": {
+        "0.3.7": {
+          "version": "0.2.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.7": {
+          "version": "0.2.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-mobile": {
+        "0.2.2": {
+          "version": "0.1.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.2": {
+          "version": "0.1.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-pc": {
+        "0.10.25": {
+          "version": "0.8.25",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.9.25": {
+          "version": "0.8.25",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-plugin": {
+        "0.10.25": {
+          "version": "0.8.25",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.9.25": {
+          "version": "0.8.25",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-plugin-map-view": {
+        "0.1.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.4": {
+          "version": "0.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-plugins": {
+        "1.1.9": {
+          "version": "1.0.9",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.9": {
+          "version": "1.0.9",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-react-node": {
+        "1.5.8": {
+          "version": "1.4.8",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.6.8": {
+          "version": "1.4.8",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-ssr": {
+        "0.2.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/g6-wx": {
+        "0.1.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gatsby-theme": {
+        "0.2.0": {
+          "version": "0.1.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.0": {
+          "version": "0.1.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/geo-coord": {
+        "1.1.8": {
+          "version": "1.0.8",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.8": {
+          "version": "1.0.8",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-assets-advance": {
+        "2.6.22": {
+          "version": "2.5.22",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.7.22": {
+          "version": "2.5.22",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-assets-algorithm": {
+        "2.4.19": {
+          "version": "2.3.19",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.5.19": {
+          "version": "2.3.19",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-assets-basic": {
+        "2.5.40": {
+          "version": "2.4.40",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.6.40": {
+          "version": "2.4.40",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-assets-galaxybase": {
+        "1.3.15": {
+          "version": "1.2.15",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.4.15": {
+          "version": "1.2.15",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-assets-graphscope": {
+        "2.2.15": {
+          "version": "2.1.15",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.15": {
+          "version": "2.1.15",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-assets-hugegraph": {
+        "1.2.15": {
+          "version": "1.1.15",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.15": {
+          "version": "1.1.15",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-assets-janusgraph": {
+        "1.2.15": {
+          "version": "1.1.15",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.15": {
+          "version": "1.1.15",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-assets-neo4j": {
+        "2.2.15": {
+          "version": "2.1.15",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.15": {
+          "version": "2.1.15",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-assets-scene": {
+        "2.3.21": {
+          "version": "2.2.21",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.4.21": {
+          "version": "2.2.21",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-assets-tugraph": {
+        "2.2.15": {
+          "version": "2.1.15",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.15": {
+          "version": "2.1.15",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-assets-tugraph-analytics": {
+        "0.3.15": {
+          "version": "0.2.15",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.15": {
+          "version": "0.2.15",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-assets-xlab": {
+        "0.2.30": {
+          "version": "0.1.30",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.30": {
+          "version": "0.1.30",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-cli": {
+        "1.3.11": {
+          "version": "1.2.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.4.11": {
+          "version": "1.2.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-common-components": {
+        "1.4.16": {
+          "version": "1.3.16",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.5.16": {
+          "version": "1.3.16",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-mock-data": {
+        "1.1.5": {
+          "version": "1.0.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.5": {
+          "version": "1.0.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-public-data": {
+        "1.1.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-sdk": {
+        "3.1.0": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.2.0": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-sdk-app": {
+        "1.3.10": {
+          "version": "1.2.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.4.10": {
+          "version": "1.2.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gi-theme-antd": {
+        "0.7.11": {
+          "version": "0.6.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.8.11": {
+          "version": "0.6.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/github-config-cli": {
+        "0.2.0": {
+          "version": "0.1.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.0": {
+          "version": "0.1.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gl-matrix": {
+        "2.8.1": {
+          "version": "2.7.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.9.1": {
+          "version": "2.7.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gpt-vis": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/gpt-vis-ssr": {
+        "0.4.7": {
+          "version": "0.3.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.5.7": {
+          "version": "0.3.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/graphin": {
+        "3.1.5": {
+          "version": "3.0.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.2.5": {
+          "version": "3.0.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/graphin-components": {
+        "2.5.1": {
+          "version": "2.4.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.6.1": {
+          "version": "2.4.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/graphin-graphscope": {
+        "1.1.5": {
+          "version": "1.0.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.5": {
+          "version": "1.0.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/graphin-icons": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/graphlib": {
+        "2.1.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/hierarchy": {
+        "0.8.1": {
+          "version": "0.7.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.9.1": {
+          "version": "0.7.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/infographic": {
+        "0.3.19": {
+          "version": "0.2.19",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.19": {
+          "version": "0.2.19",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/insight-component": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/interaction": {
+        "0.2.5": {
+          "version": "0.1.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.5": {
+          "version": "0.1.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/istanbul": {
+        "0.1.0": {
+          "version": "0.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.0": {
+          "version": "0.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/knowledge": {
+        "1.2.4": {
+          "version": "1.1.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.4": {
+          "version": "1.1.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-component": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-composite-layers": {
+        "0.18.1": {
+          "version": "0.17.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.19.1": {
+          "version": "0.17.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-core": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-district": {
+        "2.4.12": {
+          "version": "2.3.12",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.5.12": {
+          "version": "2.3.12",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-draw": {
+        "3.2.5": {
+          "version": "3.1.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.3.5": {
+          "version": "3.1.5",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-editor": {
+        "1.2.13": {
+          "version": "1.1.13",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.13": {
+          "version": "1.1.13",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-extension-g-layer": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-layers": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-leaflet": {
+        "1.1.2": {
+          "version": "1.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.2": {
+          "version": "1.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-map": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-mapkit": {
+        "0.6.0": {
+          "version": "0.5.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.7.0": {
+          "version": "0.5.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-maps": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-mini": {
+        "2.21.8": {
+          "version": "2.20.8",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.22.8": {
+          "version": "2.20.8",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-pass": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-react": {
+        "2.5.3": {
+          "version": "2.4.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.6.3": {
+          "version": "2.4.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-renderer": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-scene": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-source": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-three": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7-utils": {
+        "2.26.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.27.10": {
+          "version": "2.25.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7plot": {
+        "0.6.11": {
+          "version": "0.5.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.7.11": {
+          "version": "0.5.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/l7plot-component": {
+        "0.1.11": {
+          "version": "0.0.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.11": {
+          "version": "0.0.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/larkmap": {
+        "1.6.1": {
+          "version": "1.5.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.7.1": {
+          "version": "1.5.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/layout-gpu": {
+        "1.2.7": {
+          "version": "1.1.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.7": {
+          "version": "1.1.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/layout-wasm": {
+        "1.5.2": {
+          "version": "1.4.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.6.2": {
+          "version": "1.4.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/li-aiearth-assets": {
+        "0.5.7": {
+          "version": "0.4.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.6.7": {
+          "version": "0.4.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/li-analysis-assets": {
+        "1.10.1": {
+          "version": "1.9.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.11.1": {
+          "version": "1.9.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/li-core-assets": {
+        "1.4.7": {
+          "version": "1.3.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.5.7": {
+          "version": "1.3.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/li-editor": {
+        "1.7.1": {
+          "version": "1.6.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.8.1": {
+          "version": "1.6.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/li-p2": {
+        "1.10.2": {
+          "version": "1.8.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.9.2": {
+          "version": "1.8.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/li-sam-assets": {
+        "0.2.4": {
+          "version": "0.1.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.4": {
+          "version": "0.1.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/li-sdk": {
+        "1.6.1": {
+          "version": "1.5.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.7.1": {
+          "version": "1.5.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/lite-insight": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/matrix-util": {
+        "3.1.4": {
+          "version": "3.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.2.4": {
+          "version": "3.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/mcp-server-antv": {
+        "0.2.8": {
+          "version": "0.1.8",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.8": {
+          "version": "0.1.8",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/mcp-server-chart": {
+        "0.10.10": {
+          "version": "0.9.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.11.10": {
+          "version": "0.9.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/my-f2": {
+        "2.2.7": {
+          "version": "2.1.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.7": {
+          "version": "2.1.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/my-f2-pc": {
+        "0.2.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/narrative-text-editor": {
+        "0.3.20": {
+          "version": "0.2.20",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.20": {
+          "version": "0.2.20",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/narrative-text-schema": {
+        "0.4.7": {
+          "version": "0.3.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.5.7": {
+          "version": "0.3.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/narrative-text-vis": {
+        "0.4.16": {
+          "version": "0.3.16",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.5.16": {
+          "version": "0.3.16",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/path-util": {
+        "3.1.1": {
+          "version": "3.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.2.1": {
+          "version": "3.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/react-g": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/s2": {
+        "2.8.1": {
+          "version": "2.7.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.9.1": {
+          "version": "2.7.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/s2-react": {
+        "2.4.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.5.1": {
+          "version": "2.3.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/s2-react-components": {
+        "2.2.2": {
+          "version": "2.1.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.2": {
+          "version": "2.1.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/s2-ssr": {
+        "0.2.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/s2-vue": {
+        "2.3.0": {
+          "version": "2.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.4.0": {
+          "version": "2.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/sam": {
+        "0.3.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/scale": {
+        "0.6.2": {
+          "version": "0.5.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.7.2": {
+          "version": "0.5.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/semantic-release-pnpm": {
+        "1.1.4": {
+          "version": "1.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.4": {
+          "version": "1.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/smart-color": {
+        "0.3.1": {
+          "version": "0.2.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.1": {
+          "version": "0.2.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/stat": {
+        "0.1.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.2": {
+          "version": "0.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/t8": {
+        "0.4.0": {
+          "version": "0.3.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.5.0": {
+          "version": "0.3.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/thumbnails": {
+        "2.1.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/thumbnails-component": {
+        "2.1.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/torch": {
+        "1.1.6": {
+          "version": "1.0.6",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.6": {
+          "version": "1.0.6",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/translator": {
+        "1.1.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/util": {
+        "3.4.11": {
+          "version": "3.3.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.5.11": {
+          "version": "3.3.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/vendor": {
+        "1.1.11": {
+          "version": "1.0.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.11": {
+          "version": "1.0.11",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/vis-predict-engine": {
+        "0.2.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.1": {
+          "version": "0.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/webgpu-graph": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/word-scale-chart": {
+        "0.4.4": {
+          "version": "0.3.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.5.4": {
+          "version": "0.3.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/wx-f2": {
+        "2.2.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "2.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6": {
+        "3.2.7": {
+          "version": "3.1.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.3.7": {
+          "version": "3.1.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-angular-shape": {
+        "3.1.1": {
+          "version": "3.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.2.1": {
+          "version": "3.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-common": {
+        "2.1.17": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.17": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-components": {
+        "0.11.7": {
+          "version": "0.10.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.12.7": {
+          "version": "0.10.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-geometry": {
+        "2.1.5": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.5": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-plugin-clipboard": {
+        "2.2.6": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.6": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-plugin-dnd": {
+        "2.2.1": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.1": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-plugin-export": {
+        "2.2.6": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.6": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-plugin-history": {
+        "2.3.4": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.4.4": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-plugin-keyboard": {
+        "2.3.3": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.4.3": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-plugin-minimap": {
+        "2.1.7": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.7": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-plugin-scroller": {
+        "2.1.10": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.10": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-plugin-selection": {
+        "2.3.2": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.4.2": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-plugin-snapline": {
+        "2.2.7": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.7": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-plugin-stencil": {
+        "2.2.5": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.5": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-plugin-transform": {
+        "2.2.8": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.8": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-react": {
+        "0.2.26": {
+          "version": "0.1.26",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.26": {
+          "version": "0.1.26",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-react-components": {
+        "2.1.9": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.9": {
+          "version": "3.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-react-shape": {
+        "3.1.1": {
+          "version": "3.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.2.1": {
+          "version": "3.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-vector": {
+        "1.5.2": {
+          "version": "1.4.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.6.2": {
+          "version": "1.4.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-vue-shape": {
+        "3.1.2": {
+          "version": "3.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.2.2": {
+          "version": "3.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/x6-vue3-shape": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/xflow": {
+        "2.2.13": {
+          "version": "2.2.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.3.13": {
+          "version": "2.2.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/xflow-core": {
+        "1.1.55": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.55": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/xflow-diff": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/xflow-extension": {
+        "1.1.55": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.55": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@antv/xflow-hook": {
+        "1.1.55": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.55": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@lint-md/cli": {
+        "2.1.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@lint-md/core": {
+        "2.1.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "@lint-md/parser": {
+        "0.1.14": {
+          "version": "0.0.14",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.14": {
+          "version": "0.0.14",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "ai-figure": {
+        "0.5.0": {
+          "version": "0.4.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.6.0": {
+          "version": "0.4.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "amapcn": {
+        "0.2.2": {
+          "version": "0.1.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.2": {
+          "version": "0.1.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "ast-plugin": {
+        "0.1.7": {
+          "version": "0.0.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.7": {
+          "version": "0.0.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "babel-plugin-version": {
+        "0.3.3": {
+          "version": "0.2.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.3": {
+          "version": "0.2.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "boring-avatars-vanilla": {
+        "1.1.2": {
+          "version": "1.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.2": {
+          "version": "1.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "byte-parser": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "canvas-nest.js": {
+        "2.1.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.4": {
+          "version": "2.0.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "echarts-for-react": {
+        "3.0.7": {
+          "version": "3.0.6",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.1.7": {
+          "version": "3.0.6",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.2.7": {
+          "version": "3.0.6",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "filesize.js": {
+        "2.1.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.0": {
+          "version": "2.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "fixed-round": {
+        "1.1.2": {
+          "version": "1.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.2": {
+          "version": "1.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "gantt-for-react": {
+        "0.3.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "jest-canvas-mock": {
+        "2.5.3": {
+          "version": "2.5.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.6.3": {
+          "version": "2.5.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.7.3": {
+          "version": "2.5.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "jest-date-mock": {
+        "1.0.11": {
+          "version": "1.0.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.1.11": {
+          "version": "1.0.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.11": {
+          "version": "1.0.10",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "jest-electron": {
+        "0.2.12": {
+          "version": "0.1.12",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.12": {
+          "version": "0.1.12",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "jest-expect": {
+        "0.1.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.2.1": {
+          "version": "0.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "jest-less-loader": {
+        "0.3.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "jest-random-mock": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "jest-url-loader": {
+        "0.2.0": {
+          "version": "0.1.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.0": {
+          "version": "0.1.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "limit-size": {
+        "0.2.4": {
+          "version": "0.1.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.4": {
+          "version": "0.1.4",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "lint-md": {
+        "0.3.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.4.0": {
+          "version": "0.2.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "lint-md-cli": {
+        "0.2.2": {
+          "version": "0.1.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.2": {
+          "version": "0.1.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "mcp-echarts": {
+        "0.8.1": {
+          "version": "0.7.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.9.1": {
+          "version": "0.7.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "mcp-mermaid": {
+        "0.5.1": {
+          "version": "0.4.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.6.1": {
+          "version": "0.4.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "miz": {
+        "1.1.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "onfire.js": {
+        "2.1.1": {
+          "version": "2.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "2.2.1": {
+          "version": "2.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "react-adsense": {
+        "0.2.0": {
+          "version": "0.1.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "0.3.0": {
+          "version": "0.1.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "relationship.js": {
+        "1.3.9": {
+          "version": "1.2.9",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.4.9": {
+          "version": "1.2.9",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "ribbon.js": {
+        "1.1.2": {
+          "version": "1.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "size-sensor": {
+        "1.0.4": {
+          "version": "1.0.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.1.4": {
+          "version": "1.0.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.4": {
+          "version": "1.0.3",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "slice.js": {
+        "1.2.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.3.1": {
+          "version": "1.1.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "timeago-react": {
+        "3.1.7": {
+          "version": "3.0.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "3.2.7": {
+          "version": "3.0.7",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "timeago.js": {
+        "4.1.2": {
+          "version": "4.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "4.2.2": {
+          "version": "4.0.2",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "uri-parse": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "word-width": {
+        "1.1.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.1": {
+          "version": "1.0.1",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
+      },
+      "xmorse": {
+        "1.1.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        },
+        "1.2.0": {
+          "version": "1.0.0",
+          "reason": "antv-block list, redirect to last clean version before 2026-05-19"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds `config["bug-versions"]` entries for the **antv-block supply-chain incident of 2026-05-19**, in which 637 versions across 317 packages were published — each minor/patch-bumped above the package's last stable release, in two batches within ~30 minutes.

Every blocked version redirects to the **last clean release**:

- normally the package's dist-tag `latest` (npm kept that tag intact for all but one package);
- where `latest` itself was compromised — only `uri-parse`, whose `latest` pointed at the malicious `1.2.0` — the newest clean **stable** version is used instead (`uri-parse` → `1.0.0`).

## Stats

- **317 packages / 637 versions** added
- diff: `package.json` only, `+3182` lines, no deletions
- `node --test` passes

## Excluded — needs manual review

- **`@antv/g6-lite`** — its only published version (`0.1.0-beta.1`) is itself the suspect one, so there is no clean version to redirect to. Left out of this PR; should be handled via package takedown instead.

## Relation to #290

This supersedes #290, which covered 269 of the 318 source packages and omitted 49 — including `uri-parse`, whose naive "default to latest" target would have pointed straight back at the malicious version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
