### PR TITLE
fix: correct redirect targets for 13 @antv/x6 packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4193,11 +4193,11 @@
       },
       "@antv/x6-common": {
         "2.1.17": {
-          "version": "3.0.0",
+          "version": "2.0.17",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         },
         "2.2.17": {
-          "version": "3.0.0",
+          "version": "2.0.17",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         }
       },
@@ -4213,11 +4213,11 @@
       },
       "@antv/x6-geometry": {
         "2.1.5": {
-          "version": "3.0.0",
+          "version": "2.0.5",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         },
         "2.2.5": {
-          "version": "3.0.0",
+          "version": "2.0.5",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         }
       },
@@ -4233,101 +4233,101 @@
       },
       "@antv/x6-plugin-dnd": {
         "2.2.1": {
-          "version": "3.0.0",
+          "version": "2.1.1",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         },
         "2.3.1": {
-          "version": "3.0.0",
+          "version": "2.1.1",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         }
       },
       "@antv/x6-plugin-export": {
         "2.2.6": {
-          "version": "3.0.0",
+          "version": "2.1.6",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         },
         "2.3.6": {
-          "version": "3.0.0",
+          "version": "2.1.6",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         }
       },
       "@antv/x6-plugin-history": {
         "2.3.4": {
-          "version": "3.0.0",
+          "version": "2.2.4",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         },
         "2.4.4": {
-          "version": "3.0.0",
+          "version": "2.2.4",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         }
       },
       "@antv/x6-plugin-keyboard": {
         "2.3.3": {
-          "version": "3.0.0",
+          "version": "2.2.3",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         },
         "2.4.3": {
-          "version": "3.0.0",
+          "version": "2.2.3",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         }
       },
       "@antv/x6-plugin-minimap": {
         "2.1.7": {
-          "version": "3.0.0",
+          "version": "2.0.7",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         },
         "2.2.7": {
-          "version": "3.0.0",
+          "version": "2.0.7",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         }
       },
       "@antv/x6-plugin-scroller": {
         "2.1.10": {
-          "version": "3.0.0",
+          "version": "2.0.10",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         },
         "2.2.10": {
-          "version": "3.0.0",
+          "version": "2.0.10",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         }
       },
       "@antv/x6-plugin-selection": {
         "2.3.2": {
-          "version": "3.0.0",
+          "version": "2.2.2",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         },
         "2.4.2": {
-          "version": "3.0.0",
+          "version": "2.2.2",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         }
       },
       "@antv/x6-plugin-snapline": {
         "2.2.7": {
-          "version": "3.0.0",
+          "version": "2.1.7",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         },
         "2.3.7": {
-          "version": "3.0.0",
+          "version": "2.1.7",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         }
       },
       "@antv/x6-plugin-stencil": {
         "2.2.5": {
-          "version": "3.0.0",
+          "version": "2.1.5",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         },
         "2.3.5": {
-          "version": "3.0.0",
+          "version": "2.1.5",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         }
       },
       "@antv/x6-plugin-transform": {
         "2.2.8": {
-          "version": "3.0.0",
+          "version": "2.1.8",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         },
         "2.3.8": {
-          "version": "3.0.0",
+          "version": "2.1.8",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         }
       },
@@ -4343,11 +4343,11 @@
       },
       "@antv/x6-react-components": {
         "2.1.9": {
-          "version": "3.0.0",
+          "version": "2.0.9",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         },
         "2.2.9": {
-          "version": "3.0.0",
+          "version": "2.0.9",
           "reason": "antv-block list, redirect to last clean version before 2026-05-19"
         }
       },


### PR DESCRIPTION
## Summary

Follow-up to #291. That PR shipped the antv-block incident list for 317 packages and used the literal string `"3.0.0"` as the placeholder redirect target for 13 of the `@antv/x6-*` entries whose canonical last-clean version was not resolved at ingest time. There is no `3.0.0` release on those lines, so the redirects were inert. This PR replaces each placeholder with the actual last clean version published before the 2026-05-19 block date, matching the wording already in the per-entry `reason` field.

## Changes

26 leaf `version` values across 13 top-level keys in `config['bug-versions']`. The blocked-version keys (the inner JSON keys) and the `reason` strings are untouched; only the leaf `"version"` moves. Diff is symmetric — 26 insertions and 26 deletions, no other bytes changed, no new top-level keys, no new sub-version keys.

| Package                   | Blocked versions | New target |
|---------------------------|------------------|------------|
| `@antv/x6-common`           | 2.1.17, 2.2.17   | 2.0.17     |
| `@antv/x6-geometry`         | 2.1.5, 2.2.5     | 2.0.5      |
| `@antv/x6-plugin-dnd`       | 2.2.1, 2.3.1     | 2.1.1      |
| `@antv/x6-plugin-export`    | 2.2.6, 2.3.6     | 2.1.6      |
| `@antv/x6-plugin-history`   | 2.3.4, 2.4.4     | 2.2.4      |
| `@antv/x6-plugin-keyboard`  | 2.3.3, 2.4.3     | 2.2.3      |
| `@antv/x6-plugin-minimap`   | 2.1.7, 2.2.7     | 2.0.7      |
| `@antv/x6-plugin-scroller`  | 2.1.10, 2.2.10   | 2.0.10     |
| `@antv/x6-plugin-selection` | 2.3.2, 2.4.2     | 2.2.2      |
| `@antv/x6-plugin-snapline`  | 2.2.7, 2.3.7     | 2.1.7      |
| `@antv/x6-plugin-stencil`   | 2.2.5, 2.3.5     | 2.1.5      |
| `@antv/x6-plugin-transform` | 2.2.8, 2.3.8     | 2.1.8      |
| `@antv/x6-react-components` | 2.1.9, 2.2.9     | 2.0.9      |

The other `@antv/x6-*` entries from #291 (e.g. `@antv/x6` itself, `x6-angular-shape`, `x6-components`, `x6-react`, `x6-react-shape`, `x6-vector`, `x6-vue-shape`, `x6-vue3-shape`, `x6-plugin-clipboard`) already have correct non-placeholder targets and are not touched.

## Test plan

- [x] `node --test test/index.test.js` — passes locally (`# Total: 497 bug pkgs and 923 bug versions`, both subtests `ok`).
- [x] Schema invariant per the test: every entry has a string `version` and a string `reason`.
- [x] No new top-level keys, no new inner version keys — the find-duplicated-property-keys CI check has the same input shape as #291 plus this 26-line value-only swap.
- [x] Trailing single newline on `package.json` preserved (`}\n}\n` at EOF, matching the pre-image).
- [ ] CI: PR title check (`@commitlint/config-angular`) — the `fix:` prefix is in the allowed type list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version mappings for `@antv/x6` packages and related plugins to ensure compatibility with stable release versions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cnpm/bug-versions/pull/292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->